### PR TITLE
feat: add cli for automation

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vitepress";
+import blogSidebar from "./sidebar.blog.json";
 
 export default defineConfig({
   srcDir: "src",
@@ -212,24 +213,7 @@ export default defineConfig({
         { text: "Ecosystem", link: "/docs/learn/ecosystem" },
         { text: "References", link: "/docs/learn/references" },
       ],
-      "/blog/": [
-        {
-          text: "Oxlint General Availability",
-          link: "/blog/2023-11-08-announcing-oxlint",
-        },
-        {
-          text: "Announcing Oxc",
-          link: "/blog/2023-11-07-announcing-oxc",
-        },
-        {
-          text: "A research on JavaScript linters",
-          link: "/blog/2022-08-08-linter-research",
-        },
-        {
-          text: "High Performance JavaScript Toolchain",
-          link: "/blog/2022-02-10-js-tooling-research",
-        },
-      ],
+      "/blog/": blogSidebar,
     },
   },
 });

--- a/.vitepress/sidebar.blog.json
+++ b/.vitepress/sidebar.blog.json
@@ -1,0 +1,18 @@
+[
+  {
+    "text": "2023-11-08<br>Oxlint General Availability",
+    "link": "/blog/2023-11-08-announcing-oxlint"
+  },
+  {
+    "text": "2023-11-07<br>Announcing Oxc",
+    "link": "/blog/2023-11-07-announcing-oxc"
+  },
+  {
+    "text": "2022-08-08<br>A research on JavaScript linters",
+    "link": "/blog/2022-08-08-linter-research"
+  },
+  {
+    "text": "2022-02-10<br>High Performance JavaScript Toolchain",
+    "link": "/blog/2022-02-10-js-tooling-research"
+  }
+]

--- a/cli/commands/create-blog-post.mts
+++ b/cli/commands/create-blog-post.mts
@@ -1,0 +1,116 @@
+import * as fs from "node:fs/promises";
+import { defineCommand } from "citty";
+import consola from "consola";
+
+export default defineCommand({
+  meta: {
+    name: "create-blog-post",
+    description: "create blog post",
+  },
+  args: {
+    date: {
+      type: "positional",
+      description: "publish date of the post",
+      required: true,
+    },
+    title: {
+      type: "positional",
+      description: "title of the post",
+      required: true,
+    },
+    slug: {
+      type: "string",
+      description: "slug of the post",
+      required: false,
+    },
+    author: {
+      type: "string",
+      description: "author ID of the post",
+      required: false,
+    },
+  },
+  async run({ args }) {
+    const { date, title, slug, author } = args;
+    const isValidDate =
+      /^(?:20\d{2})\-(?:0?[1-9]|1[012])\-(?:0?[1-9]|1\d|2\d|3[0-1])$/.test(
+        date,
+      );
+
+    if (!isValidDate) {
+      consola.error(`date is invalid: ${date}`);
+    }
+
+    await writeMarkdownFile({ date, title, slug, author });
+    await writeSidebarFile({ date, title, slug });
+
+    consola.success(`blog post created`);
+  },
+});
+
+async function writeMarkdownFile({
+  date,
+  title,
+  slug,
+  author,
+}: {
+  date: string;
+  title: string;
+  slug: string;
+  author: string;
+}) {
+  const filePath = `${process.cwd()}/src${getBlogPostUrl({
+    date,
+    title,
+    slug,
+  })}.md`;
+  const content = `
+---
+title: ${title}
+outline: deep
+authors:
+  - ${author || "# TODO: add author ID"}
+---
+
+<AppBlogPostHeader />
+`.trimStart();
+
+  await fs.writeFile(filePath, content);
+}
+
+async function writeSidebarFile({
+  date,
+  title,
+  slug,
+}: {
+  date: string;
+  title: string;
+  slug: string;
+}) {
+  const filePath = `${process.cwd()}/.vitepress/sidebar.blog.json`;
+  const currentSidebar = await fs.readFile(filePath, "utf8");
+  const sidebar = JSON.parse(currentSidebar) as Record<
+    "text" | "link",
+    string
+  >[];
+
+  sidebar.unshift({
+    text: `${date}<br>${title}`,
+    link: getBlogPostUrl({ date, title, slug }),
+  });
+
+  await fs.writeFile(filePath, JSON.stringify(sidebar, null, 2));
+}
+
+function getBlogPostUrl({
+  date,
+  title,
+  slug,
+}: {
+  date: string;
+  title: string;
+  slug: string;
+}) {
+  return `/blog/${date}-${(slug || title)
+    .toLocaleLowerCase()
+    .replace(/\s+/g, "-")}`;
+}

--- a/cli/index.mts
+++ b/cli/index.mts
@@ -1,0 +1,17 @@
+import { defineCommand, runMain } from "citty";
+import type { CommandDef } from "citty";
+
+const _rDefault = (r: any) => (r.default || r) as Promise<CommandDef>;
+
+const main = defineCommand({
+  meta: {
+    name: "pnpm run cli",
+    description: "CLI for OXC Documentation",
+  },
+  subCommands: {
+    "create-blog-post": () =>
+      import("./commands/create-blog-post.mjs").then(_rDefault),
+  },
+});
+
+runMain(main);

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vitepress dev",
     "build": "vitepress build",
     "preview": "vitepress preview",
+    "create-blog-post": "tsx ./cli/index.mts create-blog-post",
     "typecheck": "tsc",
     "prettier": "prettier"
   },
@@ -15,9 +16,13 @@
     "vue": "^3.3.8"
   },
   "devDependencies": {
+    "@types/node": "^20.10.0",
+    "citty": "^0.1.5",
+    "consola": "^3.2.3",
     "husky": "^8.0.3",
     "lint-staged": "15.0.2",
     "prettier": "^3.0.3",
+    "tsx": "^4.5.0",
     "typescript": "~5.2.2"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,21 @@ settings:
 dependencies:
   vitepress:
     specifier: 1.0.0-rc.25
-    version: 1.0.0-rc.25(@algolia/client-search@4.20.0)(search-insights@2.9.0)(typescript@5.2.2)
+    version: 1.0.0-rc.25(@algolia/client-search@4.20.0)(@types/node@20.10.0)(search-insights@2.9.0)(typescript@5.2.2)
   vue:
     specifier: ^3.3.8
     version: 3.3.8(typescript@5.2.2)
 
 devDependencies:
+  '@types/node':
+    specifier: ^20.10.0
+    version: 20.10.0
+  citty:
+    specifier: ^0.1.5
+    version: 0.1.5
+  consola:
+    specifier: ^3.2.3
+    version: 3.2.3
   husky:
     specifier: ^8.0.3
     version: 8.0.3
@@ -22,6 +31,9 @@ devDependencies:
   prettier:
     specifier: ^3.0.3
     version: 3.0.3
+  tsx:
+    specifier: ^4.5.0
+    version: 4.5.0
   typescript:
     specifier: ~5.2.2
     version: 5.2.2
@@ -238,7 +250,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm@0.18.20:
@@ -247,7 +258,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-x64@0.18.20:
@@ -256,7 +266,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-arm64@0.18.20:
@@ -265,7 +274,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-x64@0.18.20:
@@ -274,7 +282,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-arm64@0.18.20:
@@ -283,7 +290,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-x64@0.18.20:
@@ -292,7 +298,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm64@0.18.20:
@@ -301,7 +306,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm@0.18.20:
@@ -310,7 +314,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ia32@0.18.20:
@@ -319,7 +322,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-loong64@0.18.20:
@@ -328,7 +330,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-mips64el@0.18.20:
@@ -337,7 +338,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ppc64@0.18.20:
@@ -346,7 +346,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-riscv64@0.18.20:
@@ -355,7 +354,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-s390x@0.18.20:
@@ -364,7 +362,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-x64@0.18.20:
@@ -373,7 +370,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/netbsd-x64@0.18.20:
@@ -382,7 +378,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/openbsd-x64@0.18.20:
@@ -391,7 +386,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/sunos-x64@0.18.20:
@@ -400,7 +394,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-arm64@0.18.20:
@@ -409,7 +402,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-ia32@0.18.20:
@@ -418,7 +410,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-x64@0.18.20:
@@ -427,7 +418,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@jridgewell/sourcemap-codec@1.4.15:
@@ -449,6 +439,11 @@ packages:
     resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
     dev: false
 
+  /@types/node@20.10.0:
+    resolution: {integrity: sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==}
+    dependencies:
+      undici-types: 5.26.5
+
   /@types/web-bluetooth@0.0.20:
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
     dev: false
@@ -460,7 +455,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.5.0
+      vite: 4.5.0(@types/node@20.10.0)
       vue: 3.3.8(typescript@5.2.2)
     dev: false
 
@@ -678,6 +673,12 @@ packages:
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
+  /citty@0.1.5:
+    resolution: {integrity: sha512-AS7n5NSc0OQVMV9v6wt3ByujNIrne0/cTjiC2MYqhvao57VNfiuVksTSr2p17nVOhEr2KtqiAkGwHcgMC/qUuQ==}
+    dependencies:
+      consola: 3.2.3
+    dev: true
+
   /cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -700,6 +701,11 @@ packages:
   /commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+    dev: true
+
+  /consola@3.2.3:
+    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
+    engines: {node: ^14.18.0 || >=16.10.0}
     dev: true
 
   /cross-spawn@7.0.3:
@@ -763,7 +769,6 @@ packages:
       '@esbuild/win32-arm64': 0.18.20
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
-    dev: false
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -806,12 +811,17 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+    dev: true
+
+  /get-tsconfig@4.7.2:
+    resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
     dev: true
 
   /human-signals@5.0.0:
@@ -1007,6 +1017,10 @@ packages:
     hasBin: true
     dev: true
 
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
   /restore-cursor@4.0.0:
     resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1116,6 +1130,17 @@ packages:
       is-number: 7.0.0
     dev: true
 
+  /tsx@4.5.0:
+    resolution: {integrity: sha512-hgxdziy9KLaHh9KE+a6tIZFP6kb0MLq/1D0sJVifbGP4QVEYhy6+2FNn7MyCm1pMc63p9CW/L1OzdqTNPxs6rg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.18.20
+      get-tsconfig: 4.7.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /type-fest@1.4.0:
     resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
     engines: {node: '>=10'}
@@ -1126,7 +1151,10 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  /vite@4.5.0:
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  /vite@4.5.0(@types/node@20.10.0):
     resolution: {integrity: sha512-ulr8rNLA6rkyFAlVWw2q5YJ91v098AFQ2R0PRFwPzREXOUJQPtFUG0t+/ZikhaOCDqFoDhN6/v8Sq0o4araFAw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -1154,6 +1182,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.10.0
       esbuild: 0.18.20
       postcss: 8.4.31
       rollup: 3.29.4
@@ -1161,7 +1190,7 @@ packages:
       fsevents: 2.3.3
     dev: false
 
-  /vitepress@1.0.0-rc.25(@algolia/client-search@4.20.0)(search-insights@2.9.0)(typescript@5.2.2):
+  /vitepress@1.0.0-rc.25(@algolia/client-search@4.20.0)(@types/node@20.10.0)(search-insights@2.9.0)(typescript@5.2.2):
     resolution: {integrity: sha512-1dqWiHNThNrVZ08ixmfEDBEH+764KOgnev9oXga/x6cN++Vb9pnuu8p3K6DQP+KZrYcG+WiX7jxal0iSNpAWuQ==}
     hasBin: true
     peerDependencies:
@@ -1184,7 +1213,7 @@ packages:
       mark.js: 8.11.1
       minisearch: 6.2.0
       shiki: 0.14.5
-      vite: 4.5.0
+      vite: 4.5.0(@types/node@20.10.0)
       vue: 3.3.8(typescript@5.2.2)
     transitivePeerDependencies:
       - '@algolia/client-search'


### PR DESCRIPTION
I added CLI to automate blog post generation and sidebar synchronization.
From now on, you don't have to modify sidebar configuration manually every time you create blog post.

**Usage Details**

If you run:

```bash
pnpm run create-blog-post 2023-12-01 "Blog Title"
```

the result is:

- `/src/blog/2023-12-01-blog-title.md` is created
- `/.vitepress/sidebar.blog.json` is updated and the new blog post is shown in sidebar as first item

If you run:

```bash
pnpm run create-blog-post 2023-12-01 "Blog Title" --slug="custom-slug" --author=boshen
```

the result is:

- `/src/blog/2023-12-01-custom-slug.md` is created, where `boshen` is set in `authors` array of frontmatter
- `/.vitepress/sidebar.blog.json` is updated and the new blog post is shown in sidebar as first item

---

Let me merge this PR immediately, and give me any feedback so that I can improve this feature and add more commands (e.g. `create-guide`) for convenience of future development.