### PR TITLE
chore(core): refine Crowdin config

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,6 +4,5 @@ append_commit_message: false
 files:
   - source: /src/**/*.md
     ignore:
-      - /src/ja
-      - /src/zh
-    translation: /src/%two_letters_code%/**/%file_name%.md
+      - /src/%two_letters_code%/%original_path%/%original_file_name%
+    translation: /src/%two_letters_code%/%original_path%/%original_file_name%


### PR DESCRIPTION
Related to #13

Currently, files in `/src/ja` and `/src/zh` are listed up as files to translate.
I hope the files are ignored correctly.