### PR TITLE
fix missing path for edit

### DIFF
--- a/.vitepress/config/shared.ts
+++ b/.vitepress/config/shared.ts
@@ -53,6 +53,11 @@ export const sharedConfig = defineConfig({
         dateStyle: "full",
       },
     },
+    editLinks: true,
+    editLinkText: 'Edit this page',
+    repo: 'oxc-project/oxc-project.github.io',
+    docsDir: 'src/docs',
+    docsBranch: 'main',
   },
   vite: {
     resolve: {


### PR DESCRIPTION
Fixed that it used to fly when I pressed the edit link to https://github.com/oxc-project/oxc