### PR TITLE
fix(core): fix GitHub workflow event to listen

### DIFF
--- a/.github/workflows/ci-pr-label.yml
+++ b/.github/workflows/ci-pr-label.yml
@@ -1,13 +1,13 @@
 name: CI (PR Label)
 
+# This workflow needs to be run on listen `pull_request_target` event
+# instead of `pull_request`, so that actions/labeler@v4 is granted
+# write permission even when the PR comes from a folk repository.
+# Do not trust any code in this workflow for security reasons.
+#
+# Ref: https://github.com/actions/labeler#permissions
+# Ref: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
 on:
-  # This workflow needs to be run on listen `pull_request_target` event
-  # instead of `pull_request`, so that actions/labeler@v4 is granted
-  # write permission even when the PR comes from a folk repository.
-  # Do not trust any code in this workflow for security reasons.
-  #
-  # Ref: https://github.com/actions/labeler#permissions
-  # Ref: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/ci-pr-label.yml
+++ b/.github/workflows/ci-pr-label.yml
@@ -1,7 +1,14 @@
 name: CI (PR Label)
 
 on:
-  pull_request:
+  # This workflow needs to be run on listen `pull_request_target` event
+  # instead of `pull_request`, so that actions/labeler@v4 is granted
+  # write permission even when the PR comes from a folk repository.
+  # Do not trust any code in this workflow for security reasons.
+  #
+  # Ref: https://github.com/actions/labeler#permissions
+  # Ref: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
I found that `CI (PR Label)` workflow doesn't work if the PR comes from folk repositories.
I just fixed it with a notice.

@Boshen @Ubugeeei 
Let me assign you as reviewers to notify this change.