### PR TITLE
docs(core): update `note` to `info`

### DIFF
--- a/src/docs/learn/parser_in_rust/ast.md
+++ b/src/docs/learn/parser_in_rust/ast.md
@@ -165,7 +165,7 @@ enum Name {
 }
 ```
 
-:::note
+:::info
 This example is taken from [this blog post](https://adeschamps.github.io/enum-size)
 :::
 
@@ -273,7 +273,7 @@ pub struct YieldExpression<'a> {
 }
 ```
 
-:::note
+:::info
 Please be cautious if we are not comfortable dealing with lifetimes at this stage.
 Our program will work fine without a memory arena.
 

--- a/src/docs/learn/parser_in_rust/errors.md
+++ b/src/docs/learn/parser_in_rust/errors.md
@@ -73,7 +73,7 @@ pub fn parse_paren_expression(&mut self, ctx: Context) -> Result<Expression> {
 }
 ```
 
-:::note
+:::info
 
 For completeness, the lexer function `read_next_token` should also return `Result`
 when an unexpected `char` is found when lexing.

--- a/src/ja/docs/learn/parser_in_rust/ast.md
+++ b/src/ja/docs/learn/parser_in_rust/ast.md
@@ -165,7 +165,7 @@ enum Name {
 }
 ```
 
-:::note
+:::info
 This example is taken from [this blog post](https://adeschamps.github.io/enum-size)
 :::
 

--- a/src/ja/docs/learn/parser_in_rust/errors.md
+++ b/src/ja/docs/learn/parser_in_rust/errors.md
@@ -73,7 +73,7 @@ pub fn parse_paren_expression(&mut self, ctx: Context) -> Result<Expression> {
 }
 ```
 
-:::note
+:::info
 
 For completeness, the lexer function `read_next_token` should also return `Result`
 when an unexpected `char` is found when lexing.

--- a/src/zh/docs/learn/parser_in_rust/ast.md
+++ b/src/zh/docs/learn/parser_in_rust/ast.md
@@ -165,7 +165,7 @@ enum Name {
 }
 ```
 
-:::note
+:::info
 This example is taken from [this blog post](https://adeschamps.github.io/enum-size)
 :::
 

--- a/src/zh/docs/learn/parser_in_rust/errors.md
+++ b/src/zh/docs/learn/parser_in_rust/errors.md
@@ -73,7 +73,7 @@ pub fn parse_paren_expression(&mut self, ctx: Context) -> Result<Expression> {
 }
 ```
 
-:::note
+:::info
 
 For completeness, the lexer function `read_next_token` should also return `Result`
 when an unexpected `char` is found when lexing.


### PR DESCRIPTION
Looks like `vitepress` doesn't support `note`

<img width="759" alt="image" src="https://github.com/oxc-project/oxc-project.github.io/assets/29533304/eac73618-8b4a-484d-b423-09f4b5cb14df">


<img width="1470" alt="image" src="https://github.com/oxc-project/oxc-project.github.io/assets/29533304/b831a743-6d11-41a7-bf5a-4bebac2007bf">
