### PR TITLE
docs: move playground to top nav

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -16,20 +16,16 @@ export const enConfig = defineLocaleConfig("root", {
       { text: "Learn", link: "/docs/learn/parser_in_rust/intro" },
       { text: "Contribute", link: "/docs/contribute/introduction" },
       {
+        text: "Playground",
+        target: "_blank",
+        link: "https://oxc-project.github.io/oxc/playground/",
+      },
+      {
         text: "Resources",
         items: [
           { text: "Blog", link: "/blog/2023-12-12-announcing-oxlint.html" },
           { text: "Team", link: "/team" },
           { text: "Ecosystem", link: "/ecosystem" },
-          {
-            items: [
-              {
-                text: "Playground",
-                target: "_blank",
-                link: "https://oxc-project.github.io/oxc/playground/",
-              },
-            ],
-          },
         ],
       },
     ],

--- a/.vitepress/config/ja.ts
+++ b/.vitepress/config/ja.ts
@@ -40,20 +40,16 @@ export const jaConfig = defineLocaleConfig("ja", {
       { text: "学ぶ", link: "/ja/docs/learn/parser_in_rust/intro" },
       { text: "貢献", link: "/ja/docs/contribute/introduction" },
       {
+        text: "プレイグラウンド",
+        target: "_blank",
+        link: "https://oxc-project.github.io/oxc/playground/",
+      },
+      {
         text: "Resources",
         items: [
           { text: "ブログ", link: "/ja/blog/2023-12-12-announcing-oxlint.html" },
           { text: "Team", link: "/ja/team" },
           { text: "Ecosystem", link: "/ja/ecosystem" },
-          {
-            items: [
-              {
-                text: "プレイグラウンド",
-                target: "_blank",
-                link: "https://oxc-project.github.io/oxc/playground/",
-              },
-            ],
-          },
         ],
       },
     ],

--- a/.vitepress/config/zh.ts
+++ b/.vitepress/config/zh.ts
@@ -16,20 +16,16 @@ export const zhConfig = defineLocaleConfig("zh", {
       { text: "Learn", link: "/docs/learn/parser_in_rust/intro" },
       { text: "Contribute", link: "/docs/contribute/introduction" },
       {
+        text: "Playground",
+        target: "_blank",
+        link: "https://oxc-project.github.io/oxc/playground/",
+      },
+      {
         text: "Resources",
         items: [
           { text: "Blog", link: "/blog/2023-12-12-announcing-oxlint.html" },
           { text: "Team", link: "/team" },
           { text: "Ecosystem", link: "/ecosystem" },
-          {
-            items: [
-              {
-                text: "Playground",
-                target: "_blank",
-                link: "https://oxc-project.github.io/oxc/playground/",
-              },
-            ],
-          },
         ],
       },
     ],


### PR DESCRIPTION
The playground link should move the top nav better. This is a link that is clicked more often.

The vast majority of websites do this, for example
* https://vuejs.org/
* https://biomejs.dev/
* https://swc.rs/