### PR TITLE
docs: fix typo

### DIFF
--- a/src/docs/guide/usage/linter.md
+++ b/src/docs/guide/usage/linter.md
@@ -147,7 +147,7 @@ Available options:
 
 ### ESLint
 
-If you are looking for a way to use oxlint in projects that still need ESLint, You can use [eslint-plugin-oxc](https://github.com/oxc-project/eslint-plugin-oxlint) to turn off ESLint rules that are already supported by oxlint. So you can enjoy the speed of oxlint while still using ESLint.
+If you are looking for a way to use oxlint in projects that still need ESLint, You can use [eslint-plugin-oxlint](https://github.com/oxc-project/eslint-plugin-oxlint) to turn off ESLint rules that are already supported by oxlint. So you can enjoy the speed of oxlint while still using ESLint.
 
 ### lint-staged
 


### PR DESCRIPTION
The linter usage docs mention "eslint-plugin-oxc," but the package is actually called "eslint-plugin-oxlint."