### PR TITLE
[FIX] Actions checkout to v4

### DIFF
--- a/src/docs/guide/usage/linter.md
+++ b/src/docs/guide/usage/linter.md
@@ -117,7 +117,7 @@ jobs:
     name: Lint JS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: npx --yes oxlint@0.0.0 --deny-warnings # change to the latest release
 ```
 


### PR DESCRIPTION
Hi , in the `actions/checkout` documentation it recommends using version 4.

You can see this -> [https://github.com/actions/checkout](https://github.com/actions/checkout)