### PR TITLE
feat: implement RSS & Atom feeds for the English-language blog

### DIFF
--- a/.vitepress/config/index.ts
+++ b/.vitepress/config/index.ts
@@ -1,12 +1,14 @@
 import { defineConfig } from "vitepress";
 
 import { sharedConfig } from "./shared";
+import { rssConfig } from "./rss";
 import { enConfig } from "./en";
 // import { zhConfig } from "./zh";
 // import { jaConfig } from "./ja";
 
 export default defineConfig({
   ...sharedConfig,
+  ...rssConfig,
   locales: {
     ...enConfig,
     // Let's enable i18n when they are ready, i.e. most of the translations are done.

--- a/.vitepress/config/rss.ts
+++ b/.vitepress/config/rss.ts
@@ -1,0 +1,77 @@
+import path from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { defineConfig, createContentLoader, type SiteConfig } from "vitepress";
+import { Author, Feed } from "feed";
+import { sharedConfig } from "./shared";
+import { TEAM_MEMBERS_MAP } from "../theme/constants/team";
+
+// Thanks to https://laros.io/generating-an-rss-feed-with-vitepress
+export const rssConfig = defineConfig({
+  head: [
+    [
+      "link",
+      {
+        rel: "alternate",
+        type: "application/rss+xml",
+        title: "Oxc Blog (RSS)",
+        href: "/feeds/blog-en.rss",
+      },
+    ],
+    [
+      "link",
+      {
+        rel: "alternate",
+        type: "application/atom+xml",
+        title: "Oxc Blog (Atom)",
+        href: "/feeds/blog-en.atom",
+      },
+    ],
+  ],
+  buildEnd: async (config: SiteConfig) => {
+    const feed = new Feed({
+      title: "The Oxidation Compiler Blog",
+      id: "https://oxc-project.github.io",
+      link: "https://oxc-project.github.io",
+      language: "en",
+      favicon: "https://cdn.jsdelivr.net/gh/oxc-project/oxc-assets/logo-round-min.png",
+      copyright: sharedConfig.themeConfig!.footer!.copyright!,
+    });
+
+    const posts = await createContentLoader("blog/*.md", {
+      excerpt: true,
+      render: true,
+    }).load();
+
+    posts.sort((a, b) => +new Date(b.frontmatter.date as string) - +new Date(a.frontmatter.date as string));
+
+    for (const { url, excerpt, frontmatter, html } of posts) {
+      const result = url.match(/blog\/(?<dateGroup>\d{4}-\d{2}-\d{2})-.*$/);
+      // The date is required by the `feed` package, but the logic that deals with date parsing from blog posts in this repo doesn't guarantee a date
+      if (!result || !result.groups) throw new Error(`Blog post at ${url} does not have a valid date.`);
+      const { dateGroup } = result.groups;
+      const date = new Date(dateGroup);
+
+      feed.addItem({
+        title: frontmatter.title,
+        id: `https://oxc-project.github.io${url.replace(/\.html$/, "")}`,
+        link: `https://oxc-project.github.io${url.replace(/\.html$/, "")}`,
+        description: excerpt,
+        content: html,
+        author: (frontmatter.authors as string[]).map<Author>((id) => {
+          const author = TEAM_MEMBERS_MAP[id];
+
+          return {
+            name: author.name,
+            // It might simply be better to not include a link?
+            link: author.links ? author.links[0].link : undefined,
+          };
+        }),
+        date,
+      });
+    }
+
+    mkdirSync(path.join(config.outDir, "feeds"));
+    writeFileSync(path.join(config.outDir, "feeds/blog-en.rss"), feed.rss2());
+    writeFileSync(path.join(config.outDir, "feeds/blog-en.atom"), feed.atom1());
+  },
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@vueuse/core": "^10.7.2",
+    "feed": "^4.2.2",
     "vitepress": "1.1.4",
     "vue": "^3.4.14"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@vueuse/core':
         specifier: ^10.7.2
         version: 10.9.0(vue@3.4.27(typescript@5.4.5))
+      feed:
+        specifier: ^4.2.2
+        version: 4.2.2
       vitepress:
         specifier: 1.1.4
         version: 1.1.4(@algolia/client-search@4.22.1)(@types/node@20.12.11)(postcss@8.4.38)(search-insights@2.13.0)(typescript@5.4.5)
@@ -844,6 +847,10 @@ packages:
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
 
+  feed@4.2.2:
+    resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
+    engines: {node: '>=0.4.0'}
+
   file-entry-cache@5.0.1:
     resolution: {integrity: sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==}
     engines: {node: '>=4'}
@@ -1528,6 +1535,9 @@ packages:
     resolution: {integrity: sha512-CdASjNJPvRa7roO6Ra/gLYBTzYzzPyyBXxIMdGW3USQLyjWEls2RgW5UBTXaQVp+OrpeCK3bLem8smtmheoRuw==}
     engines: {node: '>= 0.4'}
 
+  sax@1.3.0:
+    resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
+
   search-insights@2.13.0:
     resolution: {integrity: sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==}
 
@@ -1940,6 +1950,10 @@ packages:
   write@1.0.3:
     resolution: {integrity: sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==}
     engines: {node: '>=4'}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
@@ -2832,6 +2846,10 @@ snapshots:
     dependencies:
       format: 0.2.2
 
+  feed@4.2.2:
+    dependencies:
+      xml-js: 1.6.11
+
   file-entry-cache@5.0.1:
     dependencies:
       flat-cache: 2.0.1
@@ -3596,6 +3614,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.1.4
 
+  sax@1.3.0: {}
+
   search-insights@2.13.0: {}
 
   semver@5.7.2: {}
@@ -4149,6 +4169,10 @@ snapshots:
   write@1.0.3:
     dependencies:
       mkdirp: 0.5.6
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.3.0
 
   yaml@2.3.4: {}
 


### PR DESCRIPTION
Fixes #104

### Notes

- Only implements RSS & Atom feeds for the English blog.
- It is only available via `<link>` tags in the header (RSS autodiscovery), and isn't linked to anywhere on the website.
- It will throw an error if it cannot find a date for a blog post, which is a breaking change from what previous date-handling code for this website does.
- I don't know what decisions you want to make (what title to use for the feeds, what path the feeds should be located at, etc.), so this PR is to get the ball rolling.
  - I'm likely not going to implement feeds for the other languages, as I'm not entirely sure how those should be handled.