### PR TITLE
fix: head configs overridden by rss config

### DIFF
--- a/.vitepress/config/index.ts
+++ b/.vitepress/config/index.ts
@@ -7,6 +7,7 @@ import { enConfig } from "./en";
 export default defineConfig({
   ...sharedConfig,
   ...rssConfig,
+  head: [...sharedConfig.head!, ...rssConfig.head!],
   locales: {
     ...enConfig,
   },


### PR DESCRIPTION
`head` in `sharedConfig` is overridden by `rssConfig`, cause website has no favicon