### PR TITLE
Fix typo in error snippet example

### DIFF
--- a/src/docs/learn/parser_in_rust/errors.md
+++ b/src/docs/learn/parser_in_rust/errors.md
@@ -118,7 +118,7 @@ We can then add an `expect` helper function for throwing an error if the token d
 /// Expect a `Kind` or return error
 pub fn expect(&mut self, kind: Kind) -> Result<()> {
     if self.at(kind) {
-        return Err(SyntaxError::UnExpectedToken);
+        return Err(SyntaxError::UnexpectedToken);
     }
     self.advance(kind);
     Ok(())


### PR DESCRIPTION
Hey!

By checking the error docs, I realized that the enum variant for `SyntaxError::UnexpectedToken` had a typo in one of the snippets. This PR fixes it :) 