### PR TITLE
fix: `code-group`s lack of ending colons

### DIFF
--- a/src/docs/contribute/linter/adding-rules.md
+++ b/src/docs/contribute/linter/adding-rules.md
@@ -360,6 +360,8 @@ fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
 }
 ```
 
+:::
+
 ### Use `CompactStr` where possible
 
 Reducing allocations as much as possible is critical for performance in `oxc`. The `String` type requires allocating memory on the heap, which costs memory and CPU cycles. It is possible to [store small strings inline](https://oxc.rs/docs/learn/performance.html#string-inlining) (up to 24 bytes on 64-bit systems) on the stack using `CompactStr`, which means we don't need to allocate memory. If the string is too large to store inline, it will allocate the necessary space. Using `CompactStr` can be used almost anywhere that has the type `String` or `&str`, and can save a significant amount memory and CPU cycles compared to the `String` type.
@@ -385,3 +387,5 @@ let element = Element {
   name: "div".to_string()
 };
 ```
+
+:::


### PR DESCRIPTION
current doc is

<img width="735" alt="image" src="https://github.com/user-attachments/assets/63c65610-5045-437c-86ed-e6419f7011cd">

after appended missing colons

<img width="387" alt="image" src="https://github.com/user-attachments/assets/36d4dea4-14f1-43d0-ba63-e16b2915515f">
