### PR TITLE
Add step to build vscode lib in contributing doc

### DIFF
--- a/src/docs/contribute/vscode.md
+++ b/src/docs/contribute/vscode.md
@@ -11,7 +11,8 @@ Build the extension and run it inside vscode:
 
 1. `pnpm install`
 2. `pnpm run build`
-3. open vscode and run the command palette (ctrl-shift-p) "Extensions: Install from VSIX..."
-4. open `./editors/vscode/oxc_language_server.vsix`
-5. open a `.js` / `.ts` file, add `debugger;` and save
-6. see the warning `eslint(no-debugger): debugger statement is not allowed - oxc`
+3. `pnpm --filter './editors/*' build`
+4. open vscode and run the command palette (ctrl-shift-p) "Extensions: Install from VSIX..."
+5. open `./editors/vscode/oxc_language_server.vsix`
+6. open a `.js` / `.ts` file, add `debugger;` and save
+7. see the warning `eslint(no-debugger): debugger statement is not allowed - oxc`

--- a/src/docs/contribute/vscode.md
+++ b/src/docs/contribute/vscode.md
@@ -10,9 +10,8 @@ outline: deep
 Build the extension and run it inside vscode:
 
 1. `pnpm install`
-2. `pnpm run build`
-3. `pnpm --filter './editors/*' build`
-4. open vscode and run the command palette (ctrl-shift-p) "Extensions: Install from VSIX..."
-5. open `./editors/vscode/oxc_language_server.vsix`
-6. open a `.js` / `.ts` file, add `debugger;` and save
-7. see the warning `eslint(no-debugger): debugger statement is not allowed - oxc`
+2. `pnpm --filter './editors/*' build`
+3. open vscode and run the command palette (ctrl-shift-p) "Extensions: Install from VSIX..."
+4. open `./editors/vscode/oxc_language_server.vsix`
+5. open a `.js` / `.ts` file, add `debugger;` and save
+6. see the warning `eslint(no-debugger): debugger statement is not allowed - oxc`


### PR DESCRIPTION
The top-level `pnpm build` will only build the `napi/*` packages, but the `editors/vscode` package needs to be built in order for the `editors/vscode/oxc_language_server.vsix` file referenced in the next steps to be generated. I'm not actually sure if the `napi/*` packages are even required to be built, so maybe step 2 could be removed as well.