### PR TITLE
chore(blog): update blog link in the header component

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -23,7 +23,7 @@ export const enConfig = defineLocaleConfig("root", {
       {
         text: "Resources",
         items: [
-          { text: "Blog", link: "/blog/2024-09-29-transformer-alpha" },
+          { text: "Blog", link: "/blog/2024-10-18-oxlint-v0.10-release" },
           { text: "Team", link: "/team" },
           { text: "Branding", link: "/branding" },
           { text: "Website GitHub", link: "https://github.com/oxc-project/oxc-project.github.io" },


### PR DESCRIPTION
In the header, the `Resources > Blog` link currently points to [Oxc Transformer Alpha](https://oxc.rs/blog/2024-09-29-transformer-alpha.html).
However, it should link to the Oxlint v0.10 Migration Guide, as the latter is the newer resource.