### PR TITLE
docs(linter): inform about oxlint-migrate

### DIFF
--- a/src/docs/guide/usage/linter.md
+++ b/src/docs/guide/usage/linter.md
@@ -96,6 +96,11 @@ See [Command-line Interface](./linter/cli)
 
 See [Configuration File](./linter/config)
 
+## Migrate from eslint v9
+
+If you have an existing `eslint.config.*` file, you can convert it to an `.oxlintrc.json` config with [oxlint-migrate](https://github.com/oxc-project/oxlint-migrate).  
+This script is still under development, please recheck the generated config file.
+
 ## Integration
 
 ### ESLint

--- a/src/docs/guide/usage/linter.md
+++ b/src/docs/guide/usage/linter.md
@@ -96,9 +96,9 @@ See [Command-line Interface](./linter/cli)
 
 See [Configuration File](./linter/config)
 
-## Migrate from eslint v9
+## Migrate from eslint flat config
 
-If you have an existing `eslint.config.*` file, you can convert it to an `.oxlintrc.json` config with [oxlint-migrate](https://github.com/oxc-project/oxlint-migrate).  
+If you have an existing `eslint.config.*` file, you can convert it to an `.oxlintrc.json` config with [oxlint-migrate](https://github.com/oxc-project/oxlint-migrate).
 This script is still under development, please recheck the generated config file.
 
 ## Integration


### PR DESCRIPTION
can be merged before releasing the next version 🥳 