### PR TITLE
Add Hey API to projects using oxc

### DIFF
--- a/src/docs/guide/projects.md
+++ b/src/docs/guide/projects.md
@@ -20,6 +20,7 @@ outline: deep
 - [napi-rs](https://github.com/napi-rs/napi-rs) - A framework for building compiled Node.js add-ons in Rust via Node-API
 - [AFFiNE](https://github.com/toeverything/affine) - Next-gen knowledge base
 - [nuxt-auth](https://github.com/sidebase/nuxt-auth) - Authentication built for Nuxt 3
+- [Hey API](https://heyapi.dev/) - OpenAPI to TypeScript codegen ecosystem
 
 ## Resolver
 


### PR DESCRIPTION
Hey API uses Oxlint to lint the platform code (we should migrate ESLint in the public monorepo at some point)