### PR TITLE
Update comparisons table in Minifier Alpha article

### DIFF
--- a/src/blog/2025-03-13-minifier-alpha.md
+++ b/src/blog/2025-03-13-minifier-alpha.md
@@ -23,11 +23,11 @@ Comparing widely-used minifiers on `typescript.js`:
 | :------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------: | --------------------------------: | --------------------------------: |
 | [typescript v4.9.5](https://www.npmjs.com/package/typescript/v/4.9.5) ([Source](https://unpkg.com/typescript@4.9.5/lib/typescript.js)) |                      `10.95 MB` |                         `1.88 MB` |                                   |
 | **Minifier**                                                                                                                           |               **Minified size** |                **Minzipped size** |                          **Time** |
-| 1. [@swc/core](packages/minifiers/minifiers/swc.ts)                                                                                    | **<sup>🏆-70% </sup>`3.32 MB`** | **<sup>🏆-54% </sup>`858.29 kB`** |        <sup>_8x_ </sup>`2,179 ms` |
-| 2. [oxc-minify](packages/minifiers/minifiers/oxc-minify.ts)                                                                            |       <sup>-69% </sup>`3.35 MB` |       <sup>-54% </sup>`860.67 kB` |        🏆<sup>_1x_ </sup>`444 ms` |
-| 5. [terser (no compress)](packages/minifiers/minifiers/terser.ts)                                                                      |       <sup>-68% </sup>`3.53 MB` |       <sup>-53% </sup>`879.30 kB` |       <sup>_24x_ </sup>`6,433 ms` |
-| 6. [esbuild](packages/minifiers/minifiers/esbuild.ts)                                                                                  |       <sup>-68% </sup>`3.49 MB` |       <sup>-51% </sup>`915.55 kB` |          <sup>_1x_ </sup>`492 ms` |
-| 7. [terser](packages/minifiers/minifiers/terser.ts) <sub title="Failed: timeout">❌ Timed out</sub>                                    |                               - |                                 - | <sup>:warning:</sup> `+10,000 ms` |
+| [@swc/core](packages/minifiers/minifiers/swc.ts)                                                                                       | **<sup>🏆-70% </sup>`3.32 MB`** | **<sup>🏆-54% </sup>`858.29 kB`** |        <sup>_5x_ </sup>`2,179 ms` |
+| [oxc-minify](packages/minifiers/minifiers/oxc-minify.ts)                                                                               |       <sup>-69% </sup>`3.35 MB` |       <sup>-54% </sup>`860.67 kB` |                       🏆 `444 ms` |
+| [terser (no compress)](packages/minifiers/minifiers/terser.ts)                                                                         |       <sup>-68% </sup>`3.53 MB` |       <sup>-53% </sup>`879.30 kB` |       <sup>_14x_ </sup>`6,433 ms` |
+| [esbuild](packages/minifiers/minifiers/esbuild.ts)                                                                                     |       <sup>-68% </sup>`3.49 MB` |       <sup>-51% </sup>`915.55 kB` |          <sup>_1x_ </sup>`492 ms` |
+| [terser](packages/minifiers/minifiers/terser.ts) <sub title="Failed: timeout">❌ Timed out</sub>                                       |                               - |                                 - | <sup>:warning:</sup> `+10,000 ms` |
 
 </div>
 


### PR DESCRIPTION
Update the comparison table on Minifier Alpha release article.

It makes sense to miss out the relatively obscure `@tdewolff/minify` and `uglify-js`. But with them removed from the table, it's potentially misleading, as it seems to suggest that Oxc is 8x faster than SWC.

This PR:

1. Updates the timing comparisons (so Oxc is 5x faster than SWC, not 8x).
2. Removes the numbering on left side. 1, 2, 5, 6, 7 looks a bit weird. And renumbering as 1, 2, 3, 4, 5 might seem disingenuous.
