### PR TITLE
Update bad-min-max-func.md

### DIFF
--- a/src/docs/guide/usage/linter/rules/oxc/bad-min-max-func.md
+++ b/src/docs/guide/usage/linter/rules/oxc/bad-min-max-func.md
@@ -31,7 +31,7 @@ Examples of **correct** code for this rule:
 
 ```javascript
 Math.max(0, Math.min(100, x));
-Math.min(0, Math.max(1000, z));
+Math.min(1000, Math.max(0, z));
 ```
 
 ## How to use


### PR DESCRIPTION
I think there's a typo in this rule's explanation. A *correct* clamp should have the *upper bound* in the `min` call, and the *lower bound* in the `max` call.

---

This PR updates the .md file directly, but I just realized that there is a code comment very similar to this .md file directly in the rule's source

https://github.com/oxc-project/oxc/blob/b9ab60bde696d2742d3c5781084ee3c7bb99821e/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs#L22-L51

Is there some some automated build step that extracts those code comment into this .md file? (In which case my change would get overwritten and I should actually change the code comment instead).