### PR TITLE
docs: update the bash script example about cloning the repo

### DIFF
--- a/src/docs/contribute/development.md
+++ b/src/docs/contribute/development.md
@@ -8,7 +8,7 @@ outline: deep
 ## Clone Repository
 
 ```bash
-git clone git@github.com:oxc-project/oxc.git
+git clone -c core.longpaths=true git@github.com:oxc-project/oxc.git
 ```
 
 ## Set Up Project


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b8b17f26-215f-4b24-81a6-09f302d6d047)

The filename of the snapshots is too long 🤣 on Windows OS.