### PR TITLE
docs(linter): clarify jsdoc/check-tag-names configuration

### DIFF
--- a/src/docs/guide/usage/linter/rules/jsdoc/check-tag-names.md
+++ b/src/docs/guide/usage/linter/rules/jsdoc/check-tag-names.md
@@ -61,8 +61,39 @@ oxlint --deny jsdoc/check-tag-names --jsdoc-plugin
 }
 ```
 
-:::
+### Options
 
+Configuration for allowed tags is done via [`settings.jsdoc.tagNamePreference`](/docs/guide/usage/linter/config-file-reference.html#settings-jsdoc-tagnamepreference). 
+There is no CLI-only parameter for this rule.
+
+You can add custom tags by adding a key-value pair where both match the name of the tag you want to add, like so:
+
+::: code-group
+
+```json [Config (.oxlintrc.json)]
+{
+  "plugins": ["jsdoc"],
+  "rules": {
+    "jsdoc/check-tag-names": "error"
+  },
+  "settings": { // [!code highlight:7]
+    "jsdoc": {
+      "tagNamePreference": {
+        "customTagName": "customTagName"
+      }
+    }
+  }
+}
+```
+
+Examples of correct code for the is rule with the above configuration, adding the `customTagName` tag :
+
+```js
+/**
+ * @customTagName
+ */
+```
+:::
 ## References
 
 - <a v-bind:href="source" target="_blank" rel="noreferrer">Rule Source</a>


### PR DESCRIPTION
Explain how custom tags can be registered to avoid false positives when using them in comments.

related issue https://github.com/oxc-project/oxc/issues/11392#issuecomment-2922183645