### PR TITLE
docs: add support for canonical urls

### DIFF
--- a/.vitepress/config/shared.ts
+++ b/.vitepress/config/shared.ts
@@ -54,6 +54,21 @@ export const sharedConfig = defineConfig({
   base: "/",
   head,
   lastUpdated: false,
+  transformHead: ({ pageData }) => {
+    const head: HeadConfig[] = [];
+    
+    if (pageData.frontmatter.canonical) {
+      head.push([
+        'link',
+        {
+          rel: 'canonical',
+          href: pageData.frontmatter.canonical
+        }
+      ]);
+    }
+    
+    return head;
+  },
   themeConfig: {
     siteTitle: "Oxc",
     logo: "https://cdn.jsdelivr.net/gh/oxc-project/oxc-assets/round.svg",


### PR DESCRIPTION
This PR adds support for a `canonical` frontmatter, allowing to specify a canonical URL for VitePress pages.