### PR TITLE
Clarified misleading example in "Configuring plugins" section

### DIFF
--- a/src/docs/guide/usage/linter/config.md
+++ b/src/docs/guide/usage/linter/config.md
@@ -161,7 +161,7 @@ Plugins can be enabled with the `plugins` property in a configuration file. The 
 ```jsonc
 {
   // Enable all of these plugins (which are enabled by default):
-  "plugins": ["react", "unicorn", "typescript", "oxc"]
+  "plugins": ["unicorn", "typescript", "oxc"]
 }
 ```
 


### PR DESCRIPTION
When I first read through the docs "chronologically", it really confused me to reach the "Plugins" docs and see the list of available plugins with their "default" check marks, because the React plugin didn't have one. The comment right above my change says literally that all those enabled plugins in this example are "enabled by default", which is wrong. I am by no means a Rust expert, but I am pretty sure that this line here defines the default-enabled plugins to be OXC, Unicorn and TypeScript: https://github.com/oxc-project/oxc/blob/42de3d14da0a1c4f1a80c9e692627e928d556389/crates/oxc_linter/src/config/plugins.rs#L61, which means that the "Plugins" docs' table is correct, and this example config's comment here is not.

An alternative change would be to change the comment (instead of the code) to something like `// Enable the React plugin, in addition to the default plugins`. This would also implicitly highlight the fact once more that the `plugins` array needs to contain all enabled plugins, including the ones that are enabled out of the box.