### PR TITLE
docs: correct typo for no-console rule

### DIFF
--- a/src/docs/guide/usage/linter/rules/eslint/no-console.md
+++ b/src/docs/guide/usage/linter/rules/eslint/no-console.md
@@ -60,7 +60,7 @@ Example of **incorrect** code for this option:
 console.log("foo");
 ```
 
-Example of **incorrect** code for this option:
+Example of **correct** code for this option:
 
 ```javascript
 console.info("foo");


### PR DESCRIPTION
When adding the following to .oxlintrc.json:

```
    "no-console": [
      "error",
      {
        "allow": [
          "info"
        ]
      }
    ],
```

`console.info("foo");` would be allowed.

Docs for the code example above state: _Example of **incorrect** code for this option:_