### PR TITLE
docs: fix backtick formatting in no-return-wrap.md

### DIFF
--- a/src/docs/guide/usage/linter/rules/promise/no-return-wrap.md
+++ b/src/docs/guide/usage/linter/rules/promise/no-return-wrap.md
@@ -30,7 +30,7 @@ There is an option to turn off the enforcing of 2, see the options section below
 
 ### Why is this bad?
 
-It is unnecessary to use `Promise.resolve` and Promise.reject`for converting raw values
+It is unnecessary to use `Promise.resolve` and `Promise.reject` for converting raw values
 to promises in the return statements of`then`and`catch`callbacks. Using these
 operations to convert raw values to promises is unnecessary as simply returning the raw
 value for the success case and throwing the raw error value in the failure case have the


### PR DESCRIPTION
Adds a missing code tick before `Promise.reject`, fixing the paragraph's code/text formatting.

<img width="802" height="259" alt="Screenshot of the paragraph today where most text after Promise.reject is inline code, not plain text" src="https://github.com/user-attachments/assets/90151450-ed31-4e8c-8a6e-f17c08aaa8cc" />
