### PR TITLE
fix comment in lexer.md

### DIFF
--- a/src/docs/learn/parser_in_rust/lexer.md
+++ b/src/docs/learn/parser_in_rust/lexer.md
@@ -305,7 +305,7 @@ Tokenizing keywords will just be matching the identifier from above.
 
 ```rust
 fn match_keyword(&self, ident: &str) -> Kind {
-    // all keywords are 1 <= length <= 10
+    // all keywords are 1 < length <= 10
     if ident.len() == 1 || ident.len() > 10 {
         return Kind::Identifier;
     }


### PR DESCRIPTION
If length is 1, then function returns `Kind::Identifier`