### PR TITLE
Use pnpm instead of npm in pre-commit check

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+pnpm exec lint-staged


### PR DESCRIPTION
https://pnpm.io/cli/exec

I don't have `npm` installed, which results in 
```
/usr/bin/npx-default: No such file or directory
husky - pre-commit script failed (code 255)
```