### PR TITLE
chore: add codemod to oxc resolver

### DIFF
--- a/src/docs/guide/projects.md
+++ b/src/docs/guide/projects.md
@@ -29,6 +29,7 @@ outline: deep
 - [Biome](https://biomejs.dev) - for loading configuration
 - [turborepo](https://github.com/vercel/turborepo/pull/9134) - for `turbo-trace`
 - [dts-resolver](https://github.com/sxzz/dts-resolver) - Resolves TypeScript declaration files for dependencies
+- [codemod](https://github.com/codemod/codemod) - For module resolution in jssg codemods
 
 ## Parser
 


### PR DESCRIPTION
Codemod's jssg engine uses `oxc_resolver` for module resolution as a quickjs `ModuleResolver`

https://github.com/codemod/codemod/blob/8a79cb70d5150ed0d32febe3d422a885f390fe52/crates/codemod-sandbox/src/sandbox/resolvers/oxc_resolver.rs#L98