### PR TITLE
feat: specify that .gitignore is only respected in git repositories

### DIFF
--- a/src/docs/guide/usage/linter/generated-cli.md
+++ b/src/docs/guide/usage/linter/generated-cli.md
@@ -95,6 +95,9 @@ Arguments:
 - **`--no-ignore`** &mdash;
   Disables excluding of files from .eslintignore files, **`--ignore-path`** flags and **`--ignore-pattern`** flags
 
+> [!NOTE]
+> `.gitignore` is only respected inside a Git repository.
+
 ## Handle Warnings
 
 - **`--quiet`** &mdash;


### PR DESCRIPTION
Closes [issue 13793](https://github.com/oxc-project/oxc/issues/13793#issuecomment-3305019352).

Added a blockquote to clarify that .gitignore is only respected in git repositories. 

Followed [plugins.md](https://github.com/oxc-project/oxc-project.github.io/blob/main/src/docs/guide/usage/linter/plugins.md?plain=1#L45-L46) for formatting.

<img width="3164" height="2062" alt="image_2025-09-22_12-10-59" src="https://github.com/user-attachments/assets/375db972-2246-4b99-93a4-7e963e8b2e6a" />
