### PR TITLE
docs(profiling): expand dhat heap profiling documentation

### DIFF
--- a/src/docs/contribute/profiling.md
+++ b/src/docs/contribute/profiling.md
@@ -89,6 +89,78 @@ For more detailed CPU profiling, such as L1/L2 cache misses, cycle and instructi
 3. Once you have enabled the events you are interested in, save the template in "File > Save as Template ..." and give it a name.
 4. Now you can use this with `xctrace` by passing the template name to the `--template` option: `xcrun xctrace record --template 'My Custom CPU Counters' --output . --launch -- /path/to/oxc/target/release-with-debug/oxlint`
 
-## Heap Allocation
+## Heap Allocation - dhat
 
-Try [dhat](https://docs.rs/dhat/latest/dhat).
+[dhat](https://docs.rs/dhat/latest/dhat) is a heap profiler that can help identify memory leaks and analyze heap allocation patterns.
+
+### Setup
+
+Add dhat as a dependency to your `Cargo.toml`:
+
+```toml
+[dependencies]
+dhat = "0.3"
+```
+
+Then add a global allocator at the top of your binary crate:
+
+```rust
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+```
+
+### Profiling
+
+Create a profiler in the scope you want to profile. The profiler will track allocations from when it's created until it's dropped:
+
+```rust
+fn main() {
+    let _profiler = dhat::Profiler::new_heap();
+    // Your code here - all heap allocations will be tracked
+}
+```
+
+You can also add `_profiler` to any function to track memory only for that specific function:
+
+```rust
+fn my_function() {
+    let _profiler = dhat::Profiler::new_heap();
+    // Only allocations within this function scope will be tracked
+}
+```
+
+The profiler will automatically generate a `dhat-heap.json` file when it's dropped.
+
+### Loading and Reading the Profile
+
+After running your program, a `dhat-heap.json` file will be created in your working directory.
+
+To analyze the profile:
+
+1. Open the dhat viewer at https://nnethercote.github.io/dh_view/dh_view.html
+2. Load the `dhat-heap.json` file
+3. Select a metric in "Sort metrics" to analyze different aspects of memory usage:
+   - **"At t-gmax (bytes)"**: Shows allocations at the point of peak memory usage. Use this to identify what's consuming the most memory when your program reaches its maximum heap size.
+   - **"At t-end (bytes)"**: Shows memory that was not dropped before the profiler was destroyed. This is particularly useful for identifying memory leaks, as it reveals allocations that remain at the end of the profiled scope.
+   - **"Total (bytes)"**: Shows the total number of bytes allocated over the entire execution. Use this to identify which parts of your code are performing the most allocations, even if the memory is later freed.
+
+### Advanced: Controlling Profiler Lifetime
+
+For more control over when profiling stops, you can explicitly manage the profiler's lifetime. For example, to profile only the core logic and exclude cleanup:
+
+```rust
+struct MyApp {
+    profiler: Option<dhat::Profiler>,
+    // other fields
+}
+
+impl MyApp {
+    fn close(&mut self) {
+        // Drop the profiler here to capture the heap state before cleanup
+        self.profiler = None;
+        // cleanup code
+    }
+}
+```
+
+This pattern helps identify which data structures are holding memory at a specific point in your program's execution.


### PR DESCRIPTION
## Summary

Expanded the dhat heap profiling section in the profiling documentation based on usage examples from [oxc#14250](https://github.com/oxc-project/oxc/issues/14250#issuecomment-3365265844) and [rolldown#6121](https://github.com/rolldown/rolldown/issues/6121#issuecomment-3339019143).

Changes include:
- Setup instructions with dependency and global allocator configuration
- Profiling examples showing usage in main function and scoped profiling in any function
- Detailed explanation of dhat viewer metrics:
  - **At t-gmax (bytes)**: Peak memory usage analysis
  - **At t-end (bytes)**: Memory leak detection
  - **Total (bytes)**: Overall allocation patterns
- Advanced pattern for controlling profiler lifetime for targeted analysis

## Test plan

- [x] Documentation is clear and accurate
- [x] Code examples are correct and follow Rust best practices
- [x] Links to dhat documentation and viewer are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)