### PR TITLE
docs(linter): supports +600 rules

### DIFF
--- a/src/docs/guide/usage/linter.md
+++ b/src/docs/guide/usage/linter.md
@@ -24,7 +24,7 @@ and run Oxlint before ESLint in your local or CI setup for a quicker feedback lo
 
 - 50 - 100 times faster than ESLint, and scales with the number of CPU cores
   ([benchmark](https://github.com/oxc-project/bench-javascript-linter)).
-- Over 570 rules with a growing list from `eslint`, `typescript`, `eslint-plugin-react`,
+- Over 600 rules with a growing list from `eslint`, `typescript`, `eslint-plugin-react`,
   `eslint-plugin-jest`, `eslint-plugin-unicorn`, `eslint-plugin-jsx-a11y` and
   [many more](https://github.com/oxc-project/oxc/issues/481).
 - Supports

--- a/src/index.md
+++ b/src/index.md
@@ -20,7 +20,7 @@ features:
     link: /docs/guide/usage/parser
     linkText: Usage guide
   - title: Linter ✅
-    details: 50~100x faster than ESLint<br/>570+ rules and growing<br/>Type-aware Linting
+    details: 50~100x faster than ESLint<br/>600+ rules and growing<br/>Type-aware Linting
     link: /docs/guide/usage/linter
     linkText: Usage guide
   - title: Resolver ✅


### PR DESCRIPTION
https://oxc.rs/docs/guide/usage/linter/rules.html

> The progress of all rule implementations is tracked [here](https://github.com/oxc-project/oxc/issues/481).
> - Total number of rules: 602
> -  Rules turned on by default: 103