### PR TITLE
doc: fix npm/npx mixup in oxlint-tsgolint installation

### DIFF
--- a/src/docs/guide/usage/linter/type-aware.md
+++ b/src/docs/guide/usage/linter/type-aware.md
@@ -7,7 +7,7 @@ Read our [technical preview announcement](/blog/2025-08-17-oxlint-type-aware) fo
 ::: code-group
 
 ```sh [npm]
-npx add -D oxlint-tsgolint@latest
+npm add -D oxlint-tsgolint@latest
 ```
 
 ```sh [pnpm]


### PR DESCRIPTION
`npx add` does not exist, and should be `npm add`, just like it is documented for the base installation `npm add -D oxlint`.