### PR TITLE
docs(linter): fix typo for installing oxlint-tsgolint

### DIFF
--- a/src/docs/guide/usage/linter.md
+++ b/src/docs/guide/usage/linter.md
@@ -108,7 +108,7 @@ Oxlint supports type-aware rules in preview mode. To enable type-aware linting:
 ::: code-group
 
 ```sh [npm]
-$ npx add -D oxlint-tsgolint@latest
+$ npm add -D oxlint-tsgolint@latest
 ```
 
 ```sh [pnpm]


### PR DESCRIPTION
Follow up to #548