### PR TITLE
docs(linter/plugins): remove comments APIs from list of unsupported APIs

### DIFF
--- a/src/docs/guide/usage/linter/js-plugins.md
+++ b/src/docs/guide/usage/linter/js-plugins.md
@@ -351,7 +351,6 @@ Not supported yet:
 - Suggestions.
 - Scope analysis.
 - `SourceCode` APIs related to tokens (e.g. `context.sourceCode.getTokens(node)`).
-- `SourceCode` APIs related to comments (e.g. `context.sourceCode.getAllComments()`).
 - Control flow analysis.
 
 We will be filling in the gaps in API support over the next few months, aiming to eventually support 100% of ESLint's


### PR DESCRIPTION
These APIs were added in https://github.com/oxc-project/oxc/pull/14715.

Please merge this PR once we make next Oxlint release.