### PR TITLE
docs(linter): add ignoreRestSiblings option

### DIFF
--- a/src/docs/guide/usage/linter/rules/eslint/no-unused-vars.md
+++ b/src/docs/guide/usage/linter/rules/eslint/no-unused-vars.md
@@ -181,6 +181,23 @@ Examples of **incorrect** code for `/* exported variableName */` operation:
 var global_var = 42;
 ```
 
+### Options
+
+#### ignoreRestSiblings
+
+`{ type: boolean, default: false }`
+
+The `ignoreRestSiblings` option is set to `false` by default, meaning unused siblings of the rest parameter are flagged.
+
+With the option set to `false`, the code below would be flagged.
+
+```javascript
+const { password, ...profile } = user; // `password` is unused.
+return Response.json(profile);
+```
+
+With the option set to `true`, the code would be allowed.
+
 ## How to use
 
 To **enable** this rule in the CLI or using the config file, you can use:


### PR DESCRIPTION
Explains the `ignoreRestSiblings` config option for the [no unused vars](https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars) rule.

Related to [this](https://github.com/oxc-project/oxc/issues/14764) issue.

<img width="1903" height="958" alt="image" src="https://github.com/user-attachments/assets/b8189da4-d198-4973-adfa-94d42a9e32ca" />
