### PR TITLE
Add "Release Notes" link to navbar.

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -25,6 +25,7 @@ export const enConfig = defineLocaleConfig("root", {
         items: [
           { text: "Blog", link: "/blog/2025-10-09-oxlint-js-plugins" },
           { text: "Team", link: "/team" },
+          { text: "Release Notes", link: "https://github.com/oxc-project/oxc/releases" },
           { text: "Branding", link: "/branding" },
           { text: "Website GitHub", link: "https://github.com/oxc-project/oxc-project.github.io" },
         ],


### PR DESCRIPTION
Add "Release Notes" link:

<img width="613" height="255" alt="Screenshot 2025-11-01 at 4 08 18 PM" src="https://github.com/user-attachments/assets/c8d8ec1a-2900-48ea-820c-72febf091a7e" />

It just links to https://github.com/oxc-project/oxc/releases, we could alternatively link to the changelog file?