### PR TITLE
Add minimum `oxfmt` documentation

### DIFF
--- a/src/docs/guide/usage/formatter.md
+++ b/src/docs/guide/usage/formatter.md
@@ -1,6 +1,6 @@
 # Formatter
 
-Oxfmt (`/oh-eks-for-mat/`) is a non-opinionated yet Prettier-compatible code formatter.
+Oxfmt (`/oh-eks-for-mat/`) is a Prettier-compatible code formatter.
 
 :::info
 Oxfmt is currently working in progress.


### PR DESCRIPTION
Expanded documentation for Oxfmt, including installation instructions, command-line interface usage, configuration file details, and notable limitations.

We will split it into sub pages later.