### PR TITLE
Add link to Formatter section on Homepage.

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -36,6 +36,7 @@ features:
     link: /docs/guide/usage/minifier
   - title: Formatter 🚧
     details: Prettier compatible<br/>Prototype is complete
+    link: /docs/guide/usage/formatter
   - title: Rolldown Bundler 🚧
     details: Rollup compatible<br/>Designed for Vite
     link: https://rolldown.rs


### PR DESCRIPTION
This is the only "card" on the homepage to not link to the relevant page, so just fixing that.

cc: @leaysgur 