### PR TITLE
docs(linter): improve wording

### DIFF
--- a/src/docs/guide/usage/linter/config.md
+++ b/src/docs/guide/usage/linter/config.md
@@ -252,4 +252,4 @@ You can ignore certain patterns of files by configuring the `ignorePatterns` pro
 
 ### .eslintignore
 
-Oxlint works with our previous [.eslintignore](https://eslint.org/docs/latest/use/configure/ignore#the-eslintignore-file) file.
+Oxlint works with existing [.eslintignore](https://eslint.org/docs/latest/use/configure/ignore#the-eslintignore-file) files.

--- a/src/docs/guide/usage/linter/nested-config.md
+++ b/src/docs/guide/usage/linter/nested-config.md
@@ -3,9 +3,9 @@ outline: [2, 3]
 editLink: false
 ---
 
-# Nesting configuration files
+# Nested configuration files
 
-It is possible to have multiple configuration files within the same project, and Oxlint will automatically detect the presence of these files and use them in addition to the top-level configuration file. The files must be named `.oxlintrc.json` for this to work.
+It is possible to have multiple configuration files within the same project. Oxlint will automatically detect the presence of these files and use them in addition to the top-level configuration file. Config files must be named `.oxlintrc.json` for nested configuration to work.
 
 For example, consider the following project structure:
 
@@ -22,7 +22,7 @@ my-project/
     └── index.js
 ```
 
-Oxlint will always use the nearest configuration file to the file currently being processed and use that for linting. In the example hierarchy above, that means:
+Oxlint will always use the nearest configuration file to the file currently being processed and use that for linting. In the example above, that means:
 
 - `src/index.js` will be linted using `my-project/.oxlintrc.json`
 - `package1/index.js` will be linted using `my-project/package1/.oxlintrc.json`

--- a/src/docs/guide/usage/linter/type-aware.md
+++ b/src/docs/guide/usage/linter/type-aware.md
@@ -1,6 +1,6 @@
 # Type-Aware Linting
 
-Read our [technical preview announcement](/blog/2025-08-17-oxlint-type-aware) for technical decision and background details.
+Read our [technical preview announcement](/blog/2025-08-17-oxlint-type-aware) for background details, and the rationale for the architecture we have chosen for type-aware linting.
 
 ## Installation
 


### PR DESCRIPTION
Improve (in my opinion) the wording in a few places in linter docs, for clarity and grammar.