### PR TITLE
docs(linter): Add instructions for testing oxlint changes against another codebase

### DIFF
--- a/src/docs/contribute/linter.md
+++ b/src/docs/contribute/linter.md
@@ -23,6 +23,19 @@ Or test and filter against the rule:
 just watch "cargo test -p oxc_linter -- rule-name"
 ```
 
+### Testing oxlint against a full codebase
+
+To test oxlint on a full codebase, for example to test your changes with a large JavaScript/TypeScript project, you can build the `oxlint` CLI and run it against that codebase.
+
+```bash
+# build the oxlint cli in the oxc repo
+just oxlint-node
+# and then in the directory of the codebase you want to test with, run oxlint with node:
+node <path-to-oxc-repo>/apps/oxlint/dist/cli.js
+# You can also pass flags to it, like -D to enable a specific rule, and --disable-x-plugin to turn off default plugins:
+node <path-to-oxc-repo>/apps/oxlint/dist/cli.js -D rulename --disable-unicorn-plugin --disable-oxc-plugin --disable-typescript-plugin
+```
+
 ### Snapshot Testing
 
 [`cargo insta`](https://insta.rs/docs) is used for snapshot testing.


### PR DESCRIPTION
For testing a new rule or changes to a rule against another codebase, like vscode or mastodon.

This has been very useful for validating complicated changes like https://github.com/oxc-project/oxc/pull/15707 or https://github.com/oxc-project/oxc/pull/14602

Only caveat is that when talking to Boshen he noted the build for `oxlint` is faster than `oxlint-node`, but I'm not sure if there are downsides to using `oxlint` over `oxlint-node`?