### PR TITLE
docs(linter): fix error in `curly` `"all"` example.

### DIFF
--- a/src/docs/guide/usage/linter/rules/eslint/curly.md
+++ b/src/docs/guide/usage/linter/rules/eslint/curly.md
@@ -44,8 +44,12 @@ Examples of **correct** code for this rule:
 ```js
 /* curly: ["error", "all"] */
 
-if (foo) foo++;
-while (bar) bar--;
+if (foo) {
+  foo++;
+}
+while (bar) {
+  bar--;
+}
 do {
   foo();
 } while (bar);


### PR DESCRIPTION
The current docs' example of **correct** code for `curly` `"all"` has an error. `"all"` requires braces around the statement bodies of all control statements.