### PR TITLE
refactor: set `outline.level: [2, 3]` by default

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -264,6 +264,9 @@ export const enConfig = defineLocaleConfig("root", {
       ],
       "/blog/": BLOG_SIDEBAR,
     },
+    outline: {
+      level: [2, 3],
+    },
     editLink: {
       pattern: "https://github.com/oxc-project/oxc-project.github.io/edit/main/src/:path",
       text: "Suggest changes to this page",

--- a/src/blog/2025-10-09-oxlint-js-plugins.md
+++ b/src/blog/2025-10-09-oxlint-js-plugins.md
@@ -1,6 +1,5 @@
 ---
 title: Oxlint JS Plugins Preview
-outline: [2, 3]
 authors:
   - overlookmotel
   - cameron

--- a/src/docs/guide/usage/formatter/cli.md
+++ b/src/docs/guide/usage/formatter/cli.md
@@ -1,5 +1,4 @@
 ---
-outline: [2, 3]
 editLink: false
 ---
 

--- a/src/docs/guide/usage/formatter/config-file-reference.md
+++ b/src/docs/guide/usage/formatter/config-file-reference.md
@@ -1,5 +1,4 @@
 ---
-outline: [2, 3]
 editLink: false
 ---
 

--- a/src/docs/guide/usage/linter/automatic-fixes.md
+++ b/src/docs/guide/usage/linter/automatic-fixes.md
@@ -1,7 +1,3 @@
----
-outline: [2, 3]
----
-
 # Automatic Fixes
 
 In some cases, Oxlint is able to automatically fix lint violations in your code.

--- a/src/docs/guide/usage/linter/cli.md
+++ b/src/docs/guide/usage/linter/cli.md
@@ -1,5 +1,4 @@
 ---
-outline: [2, 3]
 editLink: false
 ---
 

--- a/src/docs/guide/usage/linter/config-file-reference.md
+++ b/src/docs/guide/usage/linter/config-file-reference.md
@@ -1,5 +1,4 @@
 ---
-outline: [2, 3]
 editLink: false
 ---
 

--- a/src/docs/guide/usage/linter/config.md
+++ b/src/docs/guide/usage/linter/config.md
@@ -1,5 +1,4 @@
 ---
-outline: [2, 3]
 editLink: false
 ---
 

--- a/src/docs/guide/usage/linter/nested-config.md
+++ b/src/docs/guide/usage/linter/nested-config.md
@@ -1,5 +1,4 @@
 ---
-outline: [2, 3]
 editLink: false
 ---
 

--- a/src/docs/guide/usage/linter/plugins.md
+++ b/src/docs/guide/usage/linter/plugins.md
@@ -1,7 +1,3 @@
----
-outline: [2, 3]
----
-
 # Plugins
 
 Oxlint supports several of the most popular ESLint plugins out of the box with

--- a/src/docs/guide/usage/linter/versioning.md
+++ b/src/docs/guide/usage/linter/versioning.md
@@ -1,5 +1,4 @@
 ---
-outline: [2, 3]
 editLink: false
 ---
 


### PR DESCRIPTION
I think this default works better for our case.