### PR TITLE
chore: Change page title from "Formatter" to "Formatter (oxfmt)"

### DIFF
--- a/src/docs/guide/usage/formatter.md
+++ b/src/docs/guide/usage/formatter.md
@@ -1,4 +1,4 @@
-# Formatter
+# Formatter (oxfmt)
 
 Oxfmt (`/oh-eks-for-mat/`) is a Prettier-compatible code formatter.
 


### PR DESCRIPTION
Minor tweak, matches the pattern from "Linter (oxlint)": https://oxc.rs/docs/guide/usage/linter.html