### PR TITLE
docs: Add note to VS Code extension Contributing page

### DIFF
--- a/src/docs/contribute/vscode.md
+++ b/src/docs/contribute/vscode.md
@@ -1,9 +1,14 @@
 ---
-title: VSCode Extension
+title: VS Code Extension
 outline: deep
 ---
 
-# VSCode Extension
+# VS Code Extension
+
+::: tip
+This page is for contributing to the Oxc VS Code extension.
+To download the extension, see the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=oxc.oxc-vscode) or the [Open VSX Registry](https://open-vsx.org/extension/oxc/oxc-vscode).
+:::
 
 ## Development
 


### PR DESCRIPTION
Add a tip to the contributing page, as it's the second result on Google when searching for "oxc VS Code" and I assume many people will click it expecting a different page :)

<img width="948" height="445" alt="Screenshot 2025-11-26 at 12 16 47 AM" src="https://github.com/user-attachments/assets/c2109734-f720-44fc-a2fe-09b005c14d72" />

Top of this oxc.rs doc page now:

<img width="741" height="211" alt="Screenshot 2025-11-26 at 12 20 14 AM" src="https://github.com/user-attachments/assets/227b24ff-b355-4073-9762-b42f5ce2d370" />

