### PR TITLE
docs(linter): Update type-aware rules list format.

### DIFF
--- a/src/docs/guide/usage/linter/type-aware.md
+++ b/src/docs/guide/usage/linter/type-aware.md
@@ -40,7 +40,7 @@ The following issues will be addressed for the alpha version.
 
 See https://github.com/oxc-project/tsgolint/issues/104
 
-## Configuration
+## Supported Rules
 
 List of supported rules:
 


### PR DESCRIPTION
I wanted an easy way to get to all the type-aware rule pages, so I made it myself :)

I opted to replace the configuration file format here with a list of links, I don't think the JSON blob was especially useful for the docs.

We should probably automate this list at some point. Also, I added one or two rules that had been added to tsgolint in the last few weeks. And cleaned up some minor phrasing.