### PR TITLE
chore: Update formatter documentation page

### DIFF
--- a/src/docs/guide/usage/formatter.md
+++ b/src/docs/guide/usage/formatter.md
@@ -108,7 +108,7 @@ In addition, `.oxfmtrc.json(c)` supports an `ignorePatterns` field.
 
 If you want to auto-format staged files with oxfmt in a git pre-commit hook, you can use `oxfmt --no-error-on-unmatched-pattern`.
 
-This command is equivalent to `"prettier --no-error-on-unmatched-pattern --write"`, and will format all matched files that are supported by oxfmt. The `--no-error-on-unmatched-pattern` flag ensures that oxfmt will not raise errors if there are no supported files passed into the command by your pre-commit hook tool (e.g. only Ruby files are staged).
+This command is equivalent to `prettier --no-error-on-unmatched-pattern --write`, and will format all matched files that are supported by oxfmt. The `--no-error-on-unmatched-pattern` flag ensures that oxfmt will not raise errors if there are no supported files passed into the command by your pre-commit hook tool (e.g. only Ruby files are staged).
 
 You can also pass `--check` to only _check_ the formatting of files, and bail if any files are incorrectly formatted.
 


### PR DESCRIPTION
Miscellaneous improvements to phrasing, and various miscellaneous clarifications to the doc page.

I have also updated the page to include a section on using oxfmt with a pre-commit hook, since I was a bit unclear on how to replace the prettier hook with oxfmt in https://github.com/oxc-project/oxlint-migrate/pull/262 / https://github.com/oxc-project/oxlint-migrate/pull/260, and Boshen ran into the same thing with https://github.com/oxc-project/oxc-walker/commit/4d765c9d71dc2496846e2f43a6dd010184c74d2b. So it seems like a good idea to explicitly document this :)
