### PR TITLE
docs(oxlint): update JS plugins API support

### DIFF
--- a/src/docs/guide/usage/linter/js-plugins.md
+++ b/src/docs/guide/usage/linter/js-plugins.md
@@ -339,12 +339,7 @@ Rust-JS interop comes into play.
 
 ## API support
 
-Oxlint supports most of the APIs typically used in plugins/rules which rely on AST inspection.
-That includes most "fix code"-type rules.
-
-It does not yet support token-based APIs, so stylistic (formatting) rules will not work yet.
-
-Supported:
+Oxlint supports most of ESLint's API surface:
 
 - AST traversal.
 - AST exploration (`node.parent`, `context.sourceCode.getAncestors`).
@@ -354,13 +349,13 @@ Supported:
 - `SourceCode` APIs (e.g. `context.sourceCode.getText(node)`).
 - `SourceCode` tokens APIs (e.g. `context.sourceCode.getTokens(node)`).
 - Scope analysis.
-- Plugins written in TypeScript (with NodeJS 22.18.0+).
 
 Not supported yet:
 
 - Language server (IDE) support.
 - Suggestions.
 - Control flow analysis.
+- Custom file formats (e.g. Svelte, Vue, Angular).
 
-We will be filling in the gaps in API support over the next few months, aiming to eventually support 100% of ESLint's
+We will be filling in the remaining gaps in API over the next few months, aiming to eventually support 100% of ESLint's
 plugin API surface.


### PR DESCRIPTION
Update list of supported/unsupported features in docs for Oxlint JS plugins.

It had got out of date. Notably it still said that we don't support token-based APIs, which we now do.

I added custom file formats to the "unsupported" section.

I've also removed plugins-written-in-TS from the "supported" section, because it only *kind of* works - the types are a bit of a mess.