### PR TITLE
Update blog link in resources section

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -23,7 +23,7 @@ export const enConfig = defineLocaleConfig("root", {
       {
         text: "Resources",
         items: [
-          { text: "Blog", link: "/blog/2025-12-08-oxfmt-alpha" },
+          { text: "Blog", link: "/blog/2025-12-08-type-aware-alpha" },
           { text: "Team", link: "/team" },
           { text: "Release Notes", link: "https://github.com/oxc-project/oxc/releases" },
           { text: "Branding", link: "/branding" },


### PR DESCRIPTION
Resources -> blog link doesn't resolve to a valid blog URL currently.

Updates this to the latest blog post as of now.