### PR TITLE
Add callouts to outdated blog posts referencing latest releases

### DIFF
--- a/src/blog/2023-12-12-announcing-oxlint.md
+++ b/src/blog/2023-12-12-announcing-oxlint.md
@@ -7,6 +7,12 @@ authors:
 
 <AppBlogPostHeader />
 
+<Alert type="info">
+
+**This post announces the initial General Availability release of Oxlint.** For the latest stable release with significantly more features and improvements, see the [Oxlint v1.0 Stable announcement](/blog/2025-06-10-oxlint-stable).
+
+</Alert>
+
 We are thrilled to announce that oxlint is now generally available!
 This milestone signifies our team's ability to promptly address and triage issues.
 

--- a/src/blog/2024-10-18-oxlint-v0.10-release.md
+++ b/src/blog/2024-10-18-oxlint-v0.10-release.md
@@ -8,6 +8,12 @@ editLink: false
 
 <AppBlogPostHeader />
 
+<Alert type="info">
+
+**This migration guide is for an older version of Oxlint.** For information about the latest stable v1.0 release, see the [Oxlint v1.0 Stable announcement](/blog/2025-06-10-oxlint-stable).
+
+</Alert>
+
 Oxlint v0.10.0 is here! This release includes several exciting features,
 including many improvements to configuration files.
 

--- a/src/blog/2025-03-15-oxlint-beta.md
+++ b/src/blog/2025-03-15-oxlint-beta.md
@@ -8,6 +8,12 @@ authors:
 
 <AppBlogPostHeader />
 
+<Alert type="info">
+
+**This post announces the beta release of Oxlint.** Oxlint has since reached v1.0 stable! See the [Oxlint v1.0 Stable announcement](/blog/2025-06-10-oxlint-stable) for the latest features and improvements.
+
+</Alert>
+
 We are thrilled to announce that Oxlint is now in beta release, after more than a year of development by the community!
 
 This milestone represents a significant step forward in feature completeness, performance, and stability.

--- a/src/blog/2025-08-17-oxlint-type-aware.md
+++ b/src/blog/2025-08-17-oxlint-type-aware.md
@@ -10,6 +10,12 @@ authors:
 
 <AppBlogPostHeader />
 
+<Alert type="info">
+
+**This post announces the technical preview of type-aware linting.** For the latest alpha release with improved stability, configurability, and rule coverage, see the [Type-Aware Linting Alpha announcement](/blog/2025-12-08-type-aware-alpha).
+
+</Alert>
+
 <br>
 
 We're thrilled to announce type-aware linting in `oxlint`!


### PR DESCRIPTION
## Summary

- Add informational callouts to outdated blog posts that direct readers to the latest relevant releases
- Improves documentation navigation by helping readers find the most current information

## Changes

Added `<Alert type="info">` callouts to four blog posts that have been superseded by newer releases:

1. **2023-12-12-announcing-oxlint.md** (Initial GA) → References v1.0 Stable
2. **2024-10-18-oxlint-v0.10-release.md** (v0.10 Migration) → References v1.0 Stable  
3. **2025-03-15-oxlint-beta.md** (Beta release) → References v1.0 Stable
4. **2025-08-17-oxlint-type-aware.md** (Type-Aware Preview) → References Type-Aware Alpha

Each callout:
- Uses consistent formatting and tone
- Appears immediately after `<AppBlogPostHeader />` for visibility
- Provides clear context about the post's historical nature
- Links to the most relevant current announcement