### PR TITLE
docs: Add prefer-nullish-coalescing to the list of type-aware linting rules.

### DIFF
--- a/src/docs/guide/usage/linter/type-aware.md
+++ b/src/docs/guide/usage/linter/type-aware.md
@@ -67,6 +67,7 @@ List of supported rules:
 - [typescript/non-nullable-type-assertion-style](/docs/guide/usage/linter/rules/typescript/non-nullable-type-assertion-style)
 - [typescript/only-throw-error](/docs/guide/usage/linter/rules/typescript/only-throw-error)
 - [typescript/prefer-includes](/docs/guide/usage/linter/rules/typescript/prefer-includes)
+- [typescript/prefer-nullish-coalescing](/docs/guide/usage/linter/rules/typescript/prefer-nullish-coalescing)
 - [typescript/prefer-promise-reject-errors](/docs/guide/usage/linter/rules/typescript/prefer-promise-reject-errors)
 - [typescript/prefer-reduce-type-parameter](/docs/guide/usage/linter/rules/typescript/prefer-reduce-type-parameter)
 - [typescript/prefer-return-this-type](/docs/guide/usage/linter/rules/typescript/prefer-return-this-type)


### PR DESCRIPTION
This shouldn't be merged until the release goes out tomorrow.

See https://github.com/oxc-project/oxc/pull/16778

We should also probably make this list automated somehow, but that's a different problem.