### PR TITLE
docs(contribute): update VS Code extension debug build settings

### DIFF
--- a/src/docs/contribute/vscode.md
+++ b/src/docs/contribute/vscode.md
@@ -55,7 +55,7 @@ Or use the Extension Settings with `settings.json`:
 
 ```json
 {
-  "oxc.path.server": "./editors/vscode/target/debug/oxc_language_server"
+  "oxc.path.oxlint": "./editors/vscode/target/debug/oxc_language_server"
 }
 ```
 


### PR DESCRIPTION
Update the settings.json example to correctly reference the debug build path for oxc_language_server. This ensures developers can properly configure the extension to use the debug build for faster development feedback.