### PR TITLE
docs(language_server): add contribute guide for `oxc_language_server`

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -258,6 +258,7 @@ export const enConfig = defineLocaleConfig("root", {
               link: "/docs/contribute/transformer",
             },
             { text: "Minifier", link: "/docs/contribute/minifier" },
+            { text: "Language Server", link: "/docs/contribute/language_server" },
             { text: "VSCode", link: "/docs/contribute/vscode" },
           ],
         },

--- a/src/docs/contribute/language_server.md
+++ b/src/docs/contribute/language_server.md
@@ -11,7 +11,7 @@ Note: In this document we will talk a lot about "tools", this is an abstract con
 
 ## `oxc_language_server` concept of implementing tools
 
-`oxc_language_server` can be used to upgrade your own script with the capability to work as an language server.
+`oxc_language_server` can be used to upgrade your own script with the capability to work as a language server.
 The server on its own does not change your files or create suggestions. This is the responsibility of the tool.
 Instead, it manages the workspace folders and all the communication for loading the right configuration.
 To communicate with the provided tools, the server provides a [`ToolBuilder` and `Tool` trait](https://github.com/oxc-project/oxc/blob/main/crates/oxc_language_server/src/tool.rs).


### PR DESCRIPTION
> This PR adds comprehensive contribution documentation for the oxc_language_server crate, explaining key concepts and differences from CLI tools.