### PR TITLE
docs: Clarify the nested config phrasing

### DIFF
--- a/src/docs/guide/usage/linter/nested-config.md
+++ b/src/docs/guide/usage/linter/nested-config.md
@@ -4,7 +4,7 @@ editLink: false
 
 # Nested configuration files
 
-It is possible to have multiple configuration files within the same project. Oxlint will automatically detect the presence of these files and use them in addition to the top-level configuration file. Config files must be named `.oxlintrc.json` for nested configuration to work.
+It is possible to have multiple configuration files within the same project. Oxlint will automatically detect the presence of these files and use them for nearby files instead of the top-level configuration file. Config files must be named `.oxlintrc.json` for nested configuration to work.
 
 For example, consider the following project structure:
 
@@ -27,7 +27,7 @@ Oxlint will always use the nearest configuration file to the file currently bein
 - `package1/index.js` will be linted using `my-project/package1/.oxlintrc.json`
 - `package2/index.js` will be linted using `my-project/package2/.oxlintrc.json`
 
-Configuration files are not automatically merged, and the configuration in a child configuration file will not affect the parent configuration. However, options passed in the command-line will override any configuration file, regardless of whether it is in the parent or child directory. In addition, using the `--config` option to specify a single file for configuration will disable the use of nested configuration files.
+Configuration files are **not automatically merged**, and the configuration in a child configuration file will not affect the parent configuration. However, options passed in the command-line will override any configuration file, regardless of whether it is in the parent or child directory. In addition, using the `--config` option to specify a single file for configuration will disable the use of nested configuration files.
 
 ## Extending configuration files
 


### PR DESCRIPTION
This actually caused a misconception for me, due to the ambiguous phrasing of "in addition to". I thought nested config files acted, basically, like overrides.