### PR TITLE
docs(linter/plugins): update JS plugins API support

### DIFF
--- a/src/docs/guide/usage/linter/js-plugins.md
+++ b/src/docs/guide/usage/linter/js-plugins.md
@@ -378,5 +378,5 @@ Not supported yet:
 - Language server (IDE) support + suggestions.
 - Custom file formats and parsers (e.g. Svelte, Vue, Angular).
 
-We will be implement the remaining features over the next few months, aiming to support 100% of ESLint's
+We will be implementing the remaining features over the next few months, aiming to support 100% of ESLint's
 plugin API surface.


### PR DESCRIPTION
https://github.com/oxc-project/oxc/pull/17229 implemented CFG support. Move that to the list of supported features.

That completes the whole API, so also update the wording else where in the doc to reflect that.