### PR TITLE
Add "quick start" section to "Migrate from Prettier" page

### DIFF
--- a/src/docs/guide/usage/formatter/migrate-from-prettier.md
+++ b/src/docs/guide/usage/formatter/migrate-from-prettier.md
@@ -6,7 +6,7 @@ Note that Oxfmt is in alpha, and may not be suitable for production use in compl
 
 ## Quick Start
 
-For simpler setups, you can migrate to Oxfmt with a single line:
+For simpler setups, you can migrate to Oxfmt with a single line in your terminal:
 
 ::: code-group
 


### PR DESCRIPTION
I think the bunx command will work but I'm admittedly not totally sure.

Regardless, this should work as a quick setup guide.

https://deploy-preview-761--oxc-project.netlify.app/docs/guide/usage/formatter/migrate-from-prettier.html