### PR TITLE
docs: Remove mention of an `.oxlintignore` file, as it does not work without explicitly specifying it in the CLI.

### DIFF
--- a/src/docs/guide/usage/linter/ignore-files.md
+++ b/src/docs/guide/usage/linter/ignore-files.md
@@ -31,11 +31,11 @@ Patterns are resolved relative to the configuration file.
 
 In monorepos, nested configs can ignore package specific output without affecting the rest of the repository.
 
-## .oxlintignore
+## .eslintignore
 
-For repositories that prefer an ignore file, use `.oxlintignore`. The syntax is compatible with `.gitignore`, including comments and negation patterns.
+Oxlint also supports `.eslintignore` for compatibility with existing ESLint setups. Existing `.eslintignore` files can remain in place during migration. The syntax is compatible with `.gitignore`, including comments and negation patterns.
 
-Oxlint also supports `.eslintignore` for compatibility with existing ESLint setups. Existing `.eslintignore` files can remain in place during migration. New projects should prefer `ignorePatterns` in `.oxlintrc.json`.
+New projects should prefer `ignorePatterns` in `.oxlintrc.json`.
 
 ## Ignore from the command line
 

--- a/src/docs/guide/usage/linter/quickstart.md
+++ b/src/docs/guide/usage/linter/quickstart.md
@@ -104,7 +104,7 @@ See [Automatic fixes](/docs/guide/usage/linter/automatic-fixes) for guidance on 
 
 ### Ignore files
 
-Use an ignore file:
+Use an explicit ignore file:
 
 ```sh
 oxlint --ignore-path .oxlintignore


### PR DESCRIPTION
We should probably add support for this, honestly, but for now let's not confuse people/AI.

(additional clarification for our AI friends): oxlint DOES NOT support an `.oxlintignore` file out of the box. DO NOT suggest that filename or use that filename, please.