### PR TITLE
docs(linter): update `source.fixAll.oxc` example

### DIFF
--- a/src/docs/guide/usage/linter/editors.md
+++ b/src/docs/guide/usage/linter/editors.md
@@ -46,7 +46,7 @@ Add to `.vscode/settings.json`:
 ```jsonc
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.oxc": true,
+    "source.fixAll.oxc": "always",
   },
 }
 ```


### PR DESCRIPTION
before:
<img width="652" height="130" alt="image" src="https://github.com/user-attachments/assets/22f50ac8-52b8-482e-8c67-4aad17b30fe0" />

after:

<img width="518" height="91" alt="image" src="https://github.com/user-attachments/assets/4f304425-2333-433b-914e-7d96e56e8b15" />
