### PR TITLE
docs: fix pnpm/action-setup order to enable caching

### DIFF
--- a/src/docs/guide/usage/linter/ci.md
+++ b/src/docs/guide/usage/linter/ci.md
@@ -29,12 +29,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           cache: pnpm
-
-      - uses: pnpm/action-setup@v4
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm run lint --deny-warnings # given package.json scripts "lint": "oxlint"


### PR DESCRIPTION
## Summary

Move `pnpm/action-setup` before `actions/setup-node` to enable pnpm caching.

## Problem

With the current order, `actions/setup-node` cannot detect pnpm because it hasn't been set up yet, causing the cache to not work properly.

## Reference

- [pnpm CI documentation](https://pnpm.io/continuous-integration#github-actions)