### PR TITLE
Align rule category badge

### DIFF
--- a/.vitepress/theme/components/RuleHeader.vue
+++ b/.vitepress/theme/components/RuleHeader.vue
@@ -107,4 +107,10 @@ const fixMessage = computed(() => {
 header .back-to-rules {
   margin-bottom: 0.5rem;
 }
+
+header h1 {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
 </style>


### PR DESCRIPTION
Fixes the alignment of the category badge.

Before:

<img width="707" height="95" alt="Screenshot 2026-01-16 at 10 41 48 PM" src="https://github.com/user-attachments/assets/e9613199-6eb0-4842-9900-c30cfa142916" />


After:

<img width="707" height="95" alt="Screenshot 2026-01-16 at 10 42 27 PM" src="https://github.com/user-attachments/assets/975dc5b3-fa70-469d-a847-f28e3cff7739" />

