### PR TITLE
docs: Add a section on usage with GitLab CI to the linter docs.

### DIFF
--- a/src/docs/guide/usage/linter/ci.md
+++ b/src/docs/guide/usage/linter/ci.md
@@ -62,9 +62,10 @@ And then add a job to your `.gitlab-ci.yml`, to run the script and upload the re
 oxlint:
   image: node:lts
   stage: test
-  script:
-    # alternatively use pnpm / yarn here
+  before_script:
+    # alternatively use pnpm install / yarn install here
     - npm install
+  script:
     - npm run lint:gitlab
   artifacts:
     reports:
@@ -74,6 +75,8 @@ oxlint:
 ```
 
 If you do not want to use the Code Quality feature, you can simply run oxlint without `--format=gitlab` in the CI job instead.
+
+You should ensure type-aware rules are enabled if you want to use them, and consider caching `node_modules` to speed up the installation of dependencies.
 
 ## Git hooks
 


### PR DESCRIPTION
I have a soft spot for GitLab CI, so I've added a docs section for running Oxlint on it :)

You can see the same config (well, basically the same) working in this Merge Request: https://gitlab.com/connorshea/oxlint-issue-repro-template/-/merge_requests/1

This results in a job run like so: https://gitlab.com/connorshea/oxlint-issue-repro-template/-/jobs/12756346820

And a merge request widget that shows this:

<img width="931" height="402" alt="Screenshot 2026-01-17 at 7 42 37 PM" src="https://github.com/user-attachments/assets/fbd76bb6-acf0-43d7-9306-d2bd1c334f0c" />

(If you have a nested repo setup this doesn't quite work right because the URLs in the merge request widget are busted, but I'm working on fixing that)

