### PR TITLE
docs: Update the doc page for embedded formatting.

### DIFF
--- a/src/docs/guide/usage/formatter/embedded-formatting.md
+++ b/src/docs/guide/usage/formatter/embedded-formatting.md
@@ -4,7 +4,7 @@
 Not fully implemented. See [tracking issue](https://github.com/oxc-project/oxc/issues/15180).
 :::
 
-Formats code embedded in JS/TS files (CSS in template literals, GraphQL, HTML in JSX).
+Formats code embedded in JS/TS files (CSS in template literals, GraphQL in template literals, JavaScript/TypeScript/CSS/etc in Markdown).
 
 ## Configuration
 
@@ -19,15 +19,50 @@ Formats code embedded in JS/TS files (CSS in template literals, GraphQL, HTML in
 - `"auto"` — (default) Format embedded sections
 - `"off"` — Skip embedded formatting
 
-## Example
+## Examples
 
 CSS inside a tagged template literal:
 
-```jsx
+```js
 const styles = css`
   .container {
     background: blue;
     color: red;
   }
 `;
+```
+
+HTML inside a tagged template literal:
+
+```js
+const template = html`
+  <div class="container">
+    <h1>Hello</h1>
+    <p>World</p>
+  </div>
+`;
+```
+
+JavaScript code blocks inside a Markdown file:
+
+````md
+This is an example Markdown file with JavaScript code blocks:
+
+```js
+const x = 1; // This will be formatted if embedded formatting is enabled.
+```
+
+Wow!
+````
+
+CSS inside a Vue file:
+
+```vue
+<style>
+/* This CSS will be formatted if embedded formatting is enabled. */
+.container {
+  background: blue;
+  color: red;
+}
+</style>
 ```


### PR DESCRIPTION
Add a few more examples of embedded formatting.

I tested and confirmed that formatting of style sections in Vue components is dependent on the embeddedLanguageFormatting setting, although I'm not 100% sure if that's intentional as it doesn't seem to be tested. Is the setting also controlling whether we use Prettier for Vue files at all?

With `embeddedLanguageFormatting: off`:

- content inside `<script>` is not formatted
- content inside `<template>` is formatted
- content inside `<style>` is not formatted

With `embeddedLanguageFormatting: auto`:

- content inside `<script>` is formatted
- content inside `<template>` is formatted
- content inside `<style>` is formatted

Not really sure why `template` gets formatted either way, but *shrug*