### PR TITLE
docs: add Astro to supported languages

### DIFF
--- a/src/docs/guide/usage/formatter.md
+++ b/src/docs/guide/usage/formatter.md
@@ -21,7 +21,7 @@ Oxfmt is currently in alpha. Please join the discussion!
 
 ## Supported languages
 
-JavaScript, JSX, TypeScript, TSX, JSON, JSONC, JSON5, YAML, TOML, HTML, Angular, Vue, CSS, SCSS, Less, Markdown, MDX, GraphQL, Ember, Handlebars
+JavaScript, JSX, TypeScript, TSX, JSON, JSONC, JSON5, YAML, TOML, HTML, Angular, Astro, Vue, CSS, SCSS, Less, Markdown, MDX, GraphQL, Ember, Handlebars
 
 ## Built for scale
 


### PR DESCRIPTION
note: no AI was used for this PR, but it was motivated by trying to get AI to setup oxlint+oxfmt. LLMs think oxc doesn't support Astro because the docs don't mention it, event hough Astro support was implemented in May 2025 via https://github.com/oxc-project/oxc/pull/1893

opencode GPT-5.2 Codex session for reference:
<img width="736" height="534" alt="image" src="https://github.com/user-attachments/assets/9df092b3-2481-4028-b9ee-0abbc2767224" />
