### PR TITLE
docs: Add a type-aware rule indicator to the rules table.

### DIFF
--- a/.vitepress/theme/components/RulesTable.vue
+++ b/.vitepress/theme/components/RulesTable.vue
@@ -260,10 +260,11 @@ const pluginDisplayNames: Record<string, string> = {
       <tr v-for="r in filteredAndSorted" :key="`${r.scope}:${r.value}`">
         <td>
           <a :href="`/docs/guide/usage/linter/rules/${r.scope}/${r.value}`">{{ r.value }}</a>
+          <span v-if="r.type_aware" title="Type-aware rule" style="margin-left: 0.4rem">💭</span>
         </td>
         <td>{{ pluginDisplayNames[r.scope] || r.scope }}</td>
         <td>{{ r.category }}</td>
-        <td v-if="r.default">✅</td>
+        <td v-if="r.default"><span title="Default enabled">✅</span></td>
         <td v-else></td>
         <td :title="fixTitle(r.fix)">{{ fixEmoji(r.fix) }}</td>
       </tr>


### PR DESCRIPTION
Adds a basic indicator so you can tell which rules are type-aware:

<img width="794" height="67" alt="Screenshot 2026-01-20 at 10 32 28 PM" src="https://github.com/user-attachments/assets/4455265e-5e8b-4ca8-8b6e-e34e36b253ba" />
