### PR TITLE
fix(docs): correct func-style namedExports default

### DIFF
--- a/src/docs/guide/usage/linter/rules/eslint/func-style.md
+++ b/src/docs/guide/usage/linter/rules/eslint/func-style.md
@@ -170,7 +170,7 @@ When true, functions with type annotations are allowed regardless of the style s
 
 type: `"ignore" | "expression" | "declaration"`
 
-default: `null`
+default: `"ignore"`
 
 Override the style specifically for named exports. Can be "expression", "declaration", or "ignore" (default).
 


### PR DESCRIPTION
The docs for eslint/func-style list namedExports default as null, but it should be "ignore". Update the configuration section to reflect the correct default.