### PR TITLE
docs: Add an example for using Oxfmt with autofix.ci and with GitLab CI, improve pre-commit hook docs

### DIFF
--- a/src/docs/guide/usage/formatter/ci.md
+++ b/src/docs/guide/usage/formatter/ci.md
@@ -127,11 +127,11 @@ You may also want to add caching for your package manager to speed up installs.
 
 ## Pre-commit hook
 
-To auto-format staged files, use `oxfmt --no-error-on-unmatched-pattern`. This formats all supported files and avoids errors when no files match (e.g., only Ruby files staged).
+To auto-format staged files, use `oxfmt --no-error-on-unmatched-pattern`. This formats all supported files and avoids errors when no files match (e.g., only Ruby files are staged).
 
 Use `--check` to verify formatting without writing files.
 
-For husky/lint-staged, add to `package.json`:
+For [lint-staged](https://github.com/lint-staged/lint-staged), add to `package.json`:
 
 ```json [package.json]
 {
@@ -140,3 +140,5 @@ For husky/lint-staged, add to `package.json`:
   }
 }
 ```
+
+To automatically install the git hook when installing dependencies, considering also using [husky](https://typicode.github.io/husky/get-started.html).

--- a/src/docs/guide/usage/linter/ci.md
+++ b/src/docs/guide/usage/linter/ci.md
@@ -105,7 +105,7 @@ You should ensure type-aware rules are enabled if you want to use them, and cons
 
 ### lint-staged
 
-For JS/TS projects using [lint-staged](https://github.com/lint-staged/lint-staged), you can set up oxlint to run pre-commit as follows:
+For JS/TS projects using [lint-staged](https://github.com/lint-staged/lint-staged), you can set up oxlint to run as a pre-commit hook as follows:
 
 ```json [package.json]
 {
@@ -114,6 +114,8 @@ For JS/TS projects using [lint-staged](https://github.com/lint-staged/lint-stage
   }
 }
 ```
+
+To automatically install the git hook when installing dependencies, considering also using [husky](https://typicode.github.io/husky/get-started.html).
 
 ### pre-commit
 


### PR DESCRIPTION
I find the autofix.ci usage in the oxc project really valuable, so I figure it's a good idea to document the concept for others to use.

lint-staged doesn't really do anything without installing the hooks, so add a note recommending to also add husky.

Includes some other minor tweaks to phrasing/the existing GitHub Actions config.