### PR TITLE
Update "Migrate from Prettier" docs

### DIFF
--- a/src/docs/guide/usage/formatter/migrate-from-prettier.md
+++ b/src/docs/guide/usage/formatter/migrate-from-prettier.md
@@ -197,4 +197,4 @@ Add the reformatting commit SHA to `.git-blame-ignore-revs` to hide it from `git
 
 ### Replace `.prettierignore` with `"ignorePatterns"`
 
-If you no longer use Prettier, you can optionally move ignored file configuration from `.prettierignore` to `"ignorePatterns"` in your Oxfmt config. See [Ignore files](/docs/guide/usage/formatter/ignore-files) for more information.
+If you no longer use Prettier, you can optionally move its contents from `.prettierignore` to `"ignorePatterns"` in your Oxfmt config. See [Ignore files](/docs/guide/usage/formatter/ignore-files) for more information.


### PR DESCRIPTION
- Add a few more details to the section on the ESLint Prettier plugin and the associated config. These changes are useful for complex setups, especially if the reader isn't aware of the specifics of eslint-plugin-prettier vs eslint-config-prettier.
- Add a note about migrating from `prettierignore` to `ignorePatterns`.
- Tweak some language