### PR TITLE
doc: Fix mistake in the type-aware doc.

### DIFF
--- a/src/docs/guide/usage/linter/type-aware.md
+++ b/src/docs/guide/usage/linter/type-aware.md
@@ -206,14 +206,14 @@ A root `tsconfig.json` with overly broad `include` patterns can inadvertently in
 }
 ```
 
-This configuration pulls in `node_modules`, build outputs, and other files that shouldn't be type-checked.
+This configuration pulls in build outputs and other files that shouldn't be type-checked.
 
 **Fix:** Explicitly scope the `include` patterns and add appropriate `exclude` entries:
 
 ```json [tsconfig.json]
 {
   "include": ["src/**/*"], // ✅ Only source files
-  "exclude": ["node_modules", "dist", "build", "coverage"]
+  "exclude": ["dist", "build", "coverage"] // node_modules are excluded by default
 }
 ```
 


### PR DESCRIPTION
node_modules is excluded by default, per the tsconfig docs. https://www.typescriptlang.org/tsconfig/#exclude