### PR TITLE
docs(formatter): add overrides configuration section

### DIFF
--- a/src/docs/guide/usage/formatter/config.md
+++ b/src/docs/guide/usage/formatter/config.md
@@ -115,6 +115,8 @@ Each override entry has:
 - `excludeFiles` (optional): Glob patterns to exclude from this override
 - `options`: Formatting options to apply
 
+Glob patterns are resolved relative to the directory containing the Oxfmt config file.
+
 ## Precedence
 
 Options are applied in order (lowest to highest priority):


### PR DESCRIPTION
## Summary
- Add documentation for the new `overrides` field in Oxfmt configuration
- Document `files`, `excludeFiles`, and `options` fields with example

Ref: https://github.com/oxc-project/oxc/pull/18068

🤖 Generated with [Claude Code](https://claude.com/claude-code)