### PR TITLE
fix: use correct cli flag for `disable-nested-config`

### DIFF
--- a/src/docs/guide/usage/linter/nested-config.md
+++ b/src/docs/guide/usage/linter/nested-config.md
@@ -44,7 +44,7 @@ Command line options override configuration files, regardless of whether they co
 
 Passing an explicit config file location using `-c` or `--config` disables nested config lookup, and Oxlint will only use that single configuration file.
 
-You can also disable nested configs with the `--disable-nested-configs` flag.
+You can also disable nested configs with the `--disable-nested-config` flag.
 
 ## Monorepo pattern: share a base config with extends
 


### PR DESCRIPTION
https://github.com/Boshen/oxc/blob/e81a306ca44d7cc1a1554652b36246a306b4ed53/apps/oxlint/src/command/lint.rs#L49-L51