### PR TITLE
docs(linter): improve style in JS plugins example

### DIFF
--- a/src/docs/guide/usage/linter/js-plugins.md
+++ b/src/docs/guide/usage/linter/js-plugins.md
@@ -280,8 +280,8 @@ const rule = defineRule({
   createOnce(context) {
     return {
       Program(node) {
-        // This always runs for every file, even if
-        // it doesn't contain any `FunctionDeclaration`s
+        // This always runs for every file, even if it
+        // doesn't contain any `FunctionDeclaration`s
       },
       FunctionDeclaration(node) {
         /* do stuff */


### PR DESCRIPTION
Tiny style improvement to Oxlint JS plugin docs. Put a line break in a more natural position in a code example.