### PR TITLE
docs(vscode): update references to oxc-vscode repository

### DIFF
--- a/src/docs/contribute/vscode.md
+++ b/src/docs/contribute/vscode.md
@@ -12,10 +12,7 @@ To download the extension, see the [Visual Studio Marketplace](https://marketpla
 
 ## Development
 
-Make sure you setup the `oxc` project with `just init`. Some tools are required for that.
-More information inside the `justfile` located on the root `oxc` project.
-
-After `just init` run `pnpm install` inside `editors/vscode` directory.
+Clone the [oxc-vscode](https://github.com/oxc-project/oxc-vscode) repository and run `pnpm install`.
 
 ## Building and running the extension locally
 
@@ -23,14 +20,14 @@ There are two options for running and testing your changes to the oxc VS Code ex
 
 **Via command line:**
 
-- Inside `editors/vscode`, run `pnpm build` to compile the vscode extension and build the release version of the language server.
+- Run `pnpm build` to compile the vscode extension and build the release version of the language server.
 - Run `pnpm install-extension` to install it on your VS Code Editor.
-- Hit `CTRL` + `SHIFT` + `P` and the search for "Developer: Reload Window".
+- Hit `CTRL` + `SHIFT` + `P` and search for "Developer: Reload Window".
 - You are now able to manually test your changes inside VS Code.
 
 **Via VS Code itself:**
 
-- Open the `oxc` repository in VS Code.
+- Open the `oxc-vscode` repository in VS Code.
 - Go to the "Run and Debug" tab in the left sidebar of your editor.
 - Select the `Launch VS Code Extension` configuration.
 - Hit the green play button at the top.
@@ -49,13 +46,13 @@ pnpm install-extension
 ```
 
 Make sure to tell the VSCode Extension to use the debug build with the env variable:
-`SERVER_PATH_DEV="/workspace/editors/vscode/target/debug/oxc_language_server"`.
+`SERVER_PATH_DEV="/workspace/oxc-vscode/target/debug/oxc_language_server"`.
 
 Or use the Extension Settings with `settings.json`:
 
 ```json
 {
-  "oxc.path.oxlint": "./editors/vscode/target/debug/oxc_language_server"
+  "oxc.path.server": "./target/debug/oxc_language_server"
 }
 ```
 

--- a/src/docs/guide/usage/formatter/editors.md
+++ b/src/docs/guide/usage/formatter/editors.md
@@ -68,7 +68,7 @@ To set per language:
 
 ### Reference
 
-- [oxc-project/oxc/editors/vscode](https://github.com/oxc-project/oxc/tree/main/editors/vscode)
+- [oxc-project/oxc-vscode](https://github.com/oxc-project/oxc-vscode)
 
 ## Zed
 

--- a/src/docs/guide/usage/linter/editors.md
+++ b/src/docs/guide/usage/linter/editors.md
@@ -63,7 +63,7 @@ You also need to ensure `oxlint-tsgolint` is installed in your project. See [the
 
 ### Reference
 
-- [oxc-project/oxc/editors/vscode](https://github.com/oxc-project/oxc/tree/main/editors/vscode)
+- [oxc-project/oxc-vscode](https://github.com/oxc-project/oxc-vscode)
 
 ## Zed
 


### PR DESCRIPTION
## Summary
- Update VS Code extension references from `oxc-project/oxc/editors/vscode` to `oxc-project/oxc-vscode`
- Simplify development instructions in contribute/vscode.md
- Update settings path from `oxc.path.oxlint` to `oxc.path.server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)