### PR TITLE
docs(linter): fix link to coc.nvim section in "setup editors"

### DIFF
--- a/src/docs/guide/usage/linter/editors.md
+++ b/src/docs/guide/usage/linter/editors.md
@@ -15,7 +15,7 @@ See [Quickstart](./quickstart) to install Oxlint.
 - [VS Code](#vs-code) (and Cursor, etc.)
 - [Zed](#zed)
 - [JetBrains](#jetbrains)
-- [coc.nvim](#cocnvim)
+- [coc.nvim](#coc-nvim)
 - [Other editors](#other-editors)
 
 ## VS Code


### PR DESCRIPTION
Fixes link to "coc.nvim" section in linter docs