### PR TITLE
docs(vscode): remove reference to local `oxc language server`

### DIFF
--- a/src/docs/contribute/vscode.md
+++ b/src/docs/contribute/vscode.md
@@ -42,7 +42,7 @@ cd apps/oxlint && pnpm build-test
 cd ../oxfmt && pnpm build-test
 ```
 
-Then configure the VS Code extension to use the debug build via the extension settings in `settings.json`:
+Then configure the VS Code extension to use the local build via the extension settings in `settings.json`:
 
 ```json
 {


### PR DESCRIPTION
> Updates the contributor documentation for the Oxc VS Code extension to remove instructions around using a locally built `oxc_language_server`, and instead describe how to test with unreleased `oxlint`/`oxfmt` builds.

The core writing was done by me, let 2 AIs correct the writing. Looks good for me :) 