### PR TITLE
docs(parser): fix outdated suggestion for expression_numeric_literal 

### DIFF
--- a/src/docs/contribute/parser/ast.md
+++ b/src/docs/contribute/parser/ast.md
@@ -148,7 +148,7 @@ Common patterns are provided as helpers:
 
 ```rust
 impl<'a> AstBuilder<'a> {
-    pub fn expression_number_literal(&self, span: Span, value: f64) -> Expression<'a> {
+    pub fn expression_numeric_literal(&self, span: Span, value: f64) -> Expression<'a> {
         self.alloc(Expression::NumericLiteral(
             self.alloc(NumericLiteral { span, value, raw: None })
         ))


### PR DESCRIPTION
`expression_number_literal` should be `expression_numeric_literal` - that's all! :)