### PR TITLE
docs: update the Contribute's Introduction page and routing name for PR rules and policies

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -360,7 +360,7 @@ export const enConfig = defineLocaleConfig("root", {
         },
         { text: "Debugging", link: "/docs/contribute/debugging" },
         { text: "Profiling", link: "/docs/contribute/profiling" },
-        { text: "Rules and Policy", link: "/docs/contribute/rules" },
+        { text: "PR Rules and Policies", link: "/docs/contribute/rules" },
         { text: "Security Policy", link: "/docs/contribute/security" },
       ],
       "/blog/": BLOG_SIDEBAR,

--- a/src/docs/contribute/introduction.md
+++ b/src/docs/contribute/introduction.md
@@ -99,5 +99,6 @@ Ready to contribute? Here are some great places to start:
 - 🔍 **Find an Issue**: Browse our [good first issues](https://github.com/oxc-project/oxc/contribute)
 - 💬 **Join the Community**: Connect with us on [Discord](https://discord.gg/9uXCAwqQZW)
 - 🛠️ **Pick a Tool**: Dive into [parser](./parser.md), [linter](./linter.md), [transformer](./transformer.md), or [other tools](./formatter.md)
+- ⚡️ **Open a Pull Request**: Review our [PR Rules and Policies](./rules.md) to get started.
 
 We can't wait to see what you'll build with us! 🚀

--- a/src/docs/contribute/rules.md
+++ b/src/docs/contribute/rules.md
@@ -1,9 +1,9 @@
 ---
-title: Rules and Policy
+title: PR Rules and Policies
 outline: deep
 ---
 
-# Introduction
+# PR Rules and Policies
 
 ## PR Rules
 


### PR DESCRIPTION
Hello,

This PR addresses issue #885 `Add a link to the PR rules on the Contribute's landing page.`  It provides the link and updates the Navigation label for the PR Rules and Policies.  I notice there were several polices so I also changed Policy to Policies and  updated the title to follow the pattern used on the other sections.  I am happy to address any comments or questions.

Before:

<img width="722" height="362" alt="Screenshot 2026-02-10 at 9 02 11 PM" src="https://github.com/user-attachments/assets/79d6574d-39a0-48d4-85f0-c674550f53f0" />

<img width="267" height="214" alt="Screenshot 2026-02-10 at 9 02 00 PM" src="https://github.com/user-attachments/assets/1be60731-6235-4e81-9d99-bdecac8430b4" />


<img width="844" height="382" alt="Screenshot 2026-02-10 at 9 01 31 PM" src="https://github.com/user-attachments/assets/35a06443-eef7-41b0-b04c-76bc1aba1282" />


After:
<img width="762" height="361" alt="Screenshot 2026-02-10 at 8 59 02 PM" src="https://github.com/user-attachments/assets/239d6cd1-6d90-4212-b634-32b47410d6e7" />

<img width="260" height="166" alt="Screenshot 2026-02-10 at 8 59 20 PM" src="https://github.com/user-attachments/assets/7825ad3e-6850-4634-9654-1cad7dc8c7b3" />

<img width="833" height="370" alt="Screenshot 2026-02-10 at 9 00 38 PM" src="https://github.com/user-attachments/assets/6aaf04c7-349d-4abb-a1db-53fd3013aa49" />

Thank you
