### PR TITLE
docs: use code-group tabs for package manager commands in quickstart pages

### DIFF
--- a/src/docs/guide/usage/formatter/quickstart.md
+++ b/src/docs/guide/usage/formatter/quickstart.md
@@ -44,15 +44,47 @@ Add scripts to `package.json`:
 
 Format files:
 
-```sh
+::: code-group
+
+```sh [npm]
+npm run fmt
+```
+
+```sh [pnpm]
 pnpm run fmt
 ```
 
+```sh [yarn]
+yarn run fmt
+```
+
+```sh [bun]
+bun run fmt
+```
+
+:::
+
 Check formatting without writing files:
 
-```sh
+::: code-group
+
+```sh [npm]
+npm run fmt:check
+```
+
+```sh [pnpm]
 pnpm run fmt:check
 ```
+
+```sh [yarn]
+yarn run fmt:check
+```
+
+```sh [bun]
+bun run fmt:check
+```
+
+:::
 
 ## Usage
 

--- a/src/docs/guide/usage/linter/quickstart.md
+++ b/src/docs/guide/usage/linter/quickstart.md
@@ -44,15 +44,47 @@ Add lint commands to `package.json`:
 
 Run it:
 
-```sh
+::: code-group
+
+```sh [npm]
+npm run lint
+```
+
+```sh [pnpm]
 pnpm run lint
 ```
 
+```sh [yarn]
+yarn run lint
+```
+
+```sh [bun]
+bun run lint
+```
+
+:::
+
 Apply fixes:
 
-```sh
+::: code-group
+
+```sh [npm]
+npm run lint:fix
+```
+
+```sh [pnpm]
 pnpm run lint:fix
 ```
+
+```sh [yarn]
+yarn run lint:fix
+```
+
+```sh [bun]
+bun run lint:fix
+```
+
+:::
 
 ## Usage
 
@@ -68,13 +100,41 @@ If `PATH` is omitted, Oxlint lints the current working directory.
 
 ### Pre-commit with [lint-staged](https://github.com/lint-staged/lint-staged)
 
-```json [package.json]
+::: code-group
+
+```json [npm]
+{
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,mjs,cjs}": "npm run lint"
+  }
+}
+```
+
+```json [pnpm]
 {
   "lint-staged": {
     "*.{js,jsx,ts,tsx,mjs,cjs}": "pnpm run lint"
   }
 }
 ```
+
+```json [yarn]
+{
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,mjs,cjs}": "yarn run lint"
+  }
+}
+```
+
+```json [bun]
+{
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx,mjs,cjs}": "bun run lint"
+  }
+}
+```
+
+:::
 
 ### Create a config file
 


### PR DESCRIPTION
The install sections on the linter and formatter quickstart pages use tabbed code groups for npm/pnpm/yarn/bun, but the "Run it", "Apply fixes", and lint-staged examples below are hardcoded to pnpm.
This wraps those commands in ::: code-group blocks with all four package managers so the tab selection stays consistent down the page.