### PR TITLE
oxfmt: Strip experimental prefixes from sorting options

### DIFF
--- a/src/docs/guide/usage/formatter/config.md
+++ b/src/docs/guide/usage/formatter/config.md
@@ -43,9 +43,9 @@ A configuration file is a JSON object. The most common top-level fields are:
 - `singleQuote`: Use single quotes (default: false)
 - `trailingComma`: Trailing commas in multi-line structures (default: "all")
 - `ignorePatterns`: Glob patterns to exclude from formatting
-- `experimentalSortImports`: Configure import sorting (disabled by default)
-- `experimentalSortPackageJson`: Configure package.json sorting (enabled by default)
-- `experimentalTailwindcss`: Configure Tailwind class sorting (disabled by default)
+- `sortImports`: Configure import sorting (disabled by default)
+- `sortTailwindcss`: Configure Tailwind class sorting (disabled by default)
+- `sortPackageJson`: Configure package.json sorting (enabled by default)
 
 For a complete list of fields, see the [Config file reference](./config-file-reference).
 

--- a/src/docs/guide/usage/formatter/sorting.md
+++ b/src/docs/guide/usage/formatter/sorting.md
@@ -10,10 +10,6 @@ See [Configuration file reference](./config-file-reference) for full details.
 
 ## Sort imports
 
-:::warning
-For progress, see [tracking issue](https://github.com/oxc-project/oxc/issues/14253).
-:::
-
 Based on [eslint-plugin-perfectionist/sort-imports](https://perfectionist.dev/rules/sort-imports).
 
 Disabled by default.
@@ -24,7 +20,7 @@ The same order as `eslint-plugin-perfectionist/sort-imports` default.
 
 ```json [.oxfmtrc.json]
 {
-  "experimentalSortImports": {
+  "sortImports": {
     "groups": [
       "type-import",
       ["value-builtin", "value-external"],
@@ -42,13 +38,35 @@ Use `"newlinesBetween": false` at the top level to disable newlines between grou
 
 ```json [.oxfmtrc.json]
 {
-  "experimentalSortImports": {
+  "sortImports": {
     "newlinesBetween": false,
     "groups": [
       ["value-builtin", "value-external"],
       ["value-internal", "value-parent", "value-sibling", "value-index"],
       { "newlinesBetween": true },
       "type-import",
+      "unknown"
+    ]
+  }
+}
+```
+
+Use `customGroups` to define your own groups for matching specific imports. Each custom group has a `groupName` that can be referenced in `groups`. The `elementNamePattern` accepts glob patterns to match import sources.
+
+```json [.oxfmtrc.json]
+{
+  "sortImports": {
+    "customGroups": [
+      {
+        "groupName": "react-libs",
+        "elementNamePattern": ["react", "react-**"]
+      }
+    ],
+    "groups": [
+      "react-libs",
+      ["value-builtin", "value-external"],
+      "value-internal",
+      ["value-parent", "value-sibling", "value-index"],
       "unknown"
     ]
   }
@@ -67,7 +85,7 @@ Disabled by default.
 
 ```json [.oxfmtrc.json]
 {
-  "experimentalTailwindcss": {
+  "sortTailwindcss": {
     "stylesheet": "./path/to/stylesheet.css",
     "functions": ["clsx", "cn"],
     "preserveWhitespace": true
@@ -91,7 +109,7 @@ To disable:
 
 ```json [.oxfmtrc.json]
 {
-  "experimentalSortPackageJson": false
+  "sortPackageJson": false
 }
 ```
 
@@ -99,7 +117,7 @@ To sort `scripts` alphabetically:
 
 ```json [.oxfmtrc.json]
 {
-  "experimentalSortPackageJson": {
+  "sortPackageJson": {
     "sortScripts": true
   }
 }

--- a/src/docs/guide/usage/formatter/unsupported-features.md
+++ b/src/docs/guide/usage/formatter/unsupported-features.md
@@ -20,15 +20,15 @@ Note: Default `printWidth` is `100` (Prettier uses `80`).
 
 Not supported. However, Oxfmt provides built-in alternatives:
 
-- `experimentalSortImports`
+- `sortImports`
   - Based on `eslint-plugin-perfectionist/sort-imports`
   - Disabled by default
-- `experimentalSortPackageJson`
-  - Based on `prettier-plugin-packagejson`
-  - Enabled by default
-- `experimentalTailwindcss`
+- `sortTailwindcss`
   - Based on `prettier-plugin-tailwindcss`
   - Disabled by default
+- `sortPackageJson`
+  - Based on `prettier-plugin-packagejson`
+  - Enabled by default
 
 See [Configuration file reference](./config-file-reference) for details.
 


### PR DESCRIPTION
Updates following the release of v0.35.