### PR TITLE
docs: map npm package links to npmx.dev

### DIFF
--- a/src/blog/2024-09-29-transformer-alpha.md
+++ b/src/blog/2024-09-29-transformer-alpha.md
@@ -30,10 +30,10 @@ In this alpha stage, we recommend to experiment with these features to speed up 
 
 ## Usage Examples
 
-### [`oxc-transform`](https://www.npmjs.com/package/oxc-transform) npm package
+### [`oxc-transform`](https://npmx.dev/package/oxc-transform) npm package
 
 Vue.js is currently [experimenting](https://github.com/vuejs/core/blob/0895b2624b707ea1e75c41f2e1f75388e7a6f101/scripts/build-types.js#L20)
-the [`oxc-transform`](https://www.npmjs.com/package/oxc-transform) npm package for isolated declarations in its build pipeline:
+the [`oxc-transform`](https://npmx.dev/package/oxc-transform) npm package for isolated declarations in its build pipeline:
 
 ```javascript
 import { isolatedDeclaration } from "oxc-transform";
@@ -103,11 +103,11 @@ On `ubuntu-latest`, an example of different lines of code are measured:
 
 Oxc downloads only 2 npm packages, a total of 2 MB.
 
-| Package                                                                                  | Size                                                                                        |
-| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| `@oxc-transform/binding-darwin-arm64`                                                    | [2.0 MB](https://www.npmjs.com/package/@oxc-transform/binding-darwin-arm64)                 |
-| `@swc/core-darwin-arm64`                                                                 | [37.5 MB](https://www.npmjs.com/package/@swc/core-darwin-arm64)                             |
-| `@babel/core` + `@babel/preset-env` + `@babel/preset-react` + `@babel/preset-typescript` | [21 MB and 170 packages](https://www.npmjs.com/package/@oxc-transform/binding-darwin-arm64) |
+| Package                                                                                  | Size                                                                                   |
+| ---------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `@oxc-transform/binding-darwin-arm64`                                                    | [2.0 MB](https://npmx.dev/package/@oxc-transform/binding-darwin-arm64)                 |
+| `@swc/core-darwin-arm64`                                                                 | [37.5 MB](https://npmx.dev/package/@swc/core-darwin-arm64)                             |
+| `@babel/core` + `@babel/preset-env` + `@babel/preset-react` + `@babel/preset-typescript` | [21 MB and 170 packages](https://npmx.dev/package/@oxc-transform/binding-darwin-arm64) |
 
 ## Memory Usage
 

--- a/src/blog/2025-03-13-minifier-alpha.md
+++ b/src/blog/2025-03-13-minifier-alpha.md
@@ -9,7 +9,7 @@ authors:
 
 <br />
 
-We are excited to announce an alpha release for [`oxc-minify`](https://www.npmjs.com/package/oxc-minify).
+We are excited to announce an alpha release for [`oxc-minify`](https://npmx.dev/package/oxc-minify).
 
 While lacking some advanced minification techniques,
 the current version already outperforms `esbuild` in terms of performance and compression size,
@@ -19,19 +19,19 @@ Comparing widely-used minifiers on `typescript.js`:
 
 <div align="center">
 
-| Artifact                                                                                                                               |                   Original size |                         Gzip size |                                   |
-| :------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------: | --------------------------------: | --------------------------------: |
-| [typescript v4.9.5](https://www.npmjs.com/package/typescript/v/4.9.5) ([Source](https://unpkg.com/typescript@4.9.5/lib/typescript.js)) |                      `10.95 MB` |                         `1.88 MB` |                                   |
-| **Minifier**                                                                                                                           |               **Minified size** |                **Minzipped size** |                          **Time** |
-| [@swc/core](packages/minifiers/minifiers/swc.ts)                                                                                       | **<sup>🏆-70% </sup>`3.32 MB`** | **<sup>🏆-54% </sup>`858.29 kB`** |        <sup>_5x_ </sup>`2,179 ms` |
-| [oxc-minify](packages/minifiers/minifiers/oxc-minify.ts)                                                                               |       <sup>-69% </sup>`3.35 MB` |       <sup>-54% </sup>`860.67 kB` |                       🏆 `444 ms` |
-| [terser (no compress)](packages/minifiers/minifiers/terser.ts)                                                                         |       <sup>-68% </sup>`3.53 MB` |       <sup>-53% </sup>`879.30 kB` |       <sup>_14x_ </sup>`6,433 ms` |
-| [esbuild](packages/minifiers/minifiers/esbuild.ts)                                                                                     |       <sup>-68% </sup>`3.49 MB` |       <sup>-51% </sup>`915.55 kB` |          <sup>_1x_ </sup>`492 ms` |
-| [terser](packages/minifiers/minifiers/terser.ts) <sub title="Failed: timeout">❌ Timed out</sub>                                       |                               - |                                 - | <sup>:warning:</sup> `+10,000 ms` |
+| Artifact                                                                                                                          |                   Original size |                         Gzip size |                                   |
+| :-------------------------------------------------------------------------------------------------------------------------------- | ------------------------------: | --------------------------------: | --------------------------------: |
+| [typescript v4.9.5](https://npmx.dev/package/typescript/v/4.9.5) ([Source](https://unpkg.com/typescript@4.9.5/lib/typescript.js)) |                      `10.95 MB` |                         `1.88 MB` |                                   |
+| **Minifier**                                                                                                                      |               **Minified size** |                **Minzipped size** |                          **Time** |
+| [@swc/core](packages/minifiers/minifiers/swc.ts)                                                                                  | **<sup>🏆-70% </sup>`3.32 MB`** | **<sup>🏆-54% </sup>`858.29 kB`** |        <sup>_5x_ </sup>`2,179 ms` |
+| [oxc-minify](packages/minifiers/minifiers/oxc-minify.ts)                                                                          |       <sup>-69% </sup>`3.35 MB` |       <sup>-54% </sup>`860.67 kB` |                       🏆 `444 ms` |
+| [terser (no compress)](packages/minifiers/minifiers/terser.ts)                                                                    |       <sup>-68% </sup>`3.53 MB` |       <sup>-53% </sup>`879.30 kB` |       <sup>_14x_ </sup>`6,433 ms` |
+| [esbuild](packages/minifiers/minifiers/esbuild.ts)                                                                                |       <sup>-68% </sup>`3.49 MB` |       <sup>-51% </sup>`915.55 kB` |          <sup>_1x_ </sup>`492 ms` |
+| [terser](packages/minifiers/minifiers/terser.ts) <sub title="Failed: timeout">❌ Timed out</sub>                                  |                               - |                                 - | <sup>:warning:</sup> `+10,000 ms` |
 
 </div>
 
-## [`oxc-minify`](https://www.npmjs.com/package/oxc-minify) Usage Example
+## [`oxc-minify`](https://npmx.dev/package/oxc-minify) Usage Example
 
 ```typescript
 import { minify } from "oxc-minify";

--- a/src/blog/2025-03-15-oxlint-beta.md
+++ b/src/blog/2025-03-15-oxlint-beta.md
@@ -22,7 +22,7 @@ This milestone represents a significant step forward in feature completeness, pe
 
 At this stage, Oxlint can be used to fully replace ESLint in small to medium projects.
 
-For larger projects, our advice is to turn off ESLint rules via [eslint-plugin-oxlint](https://www.npmjs.com/package/eslint-plugin-oxlint),
+For larger projects, our advice is to turn off ESLint rules via [eslint-plugin-oxlint](https://npmx.dev/package/eslint-plugin-oxlint),
 and run Oxlint before ESLint in your local or CI setup for a quicker feedback loop.
 
 To test Oxlint in your codebase, you can use the package manager of your choice at the root of your codebase:

--- a/src/docs/guide/projects.md
+++ b/src/docs/guide/projects.md
@@ -39,5 +39,5 @@ outline: deep
 
 ## Transformer
 
-- [unplugin-isolated-decl](https://www.npmjs.com/package/unplugin-isolated-decl) - A blazing-fast tool for generating isolated declarations
+- [unplugin-isolated-decl](https://npmx.dev/package/unplugin-isolated-decl) - A blazing-fast tool for generating isolated declarations
 - [stc](https://github.com/long-woo/stc) - A tool for converting OpenApi/Swagger/Apifox into code

--- a/src/docs/guide/usage/linter.md
+++ b/src/docs/guide/usage/linter.md
@@ -117,7 +117,7 @@ Choose the approach that fits your repository:
 - **Replace ESLint (recommended for most projects).** Use Oxlint as your primary linter.
   - Use tooling such as [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate) to migrate your existing ESLint config.
 - **Migrate incrementally (recommended for large repos).** Run Oxlint first, then run ESLint with overlapping rules disabled. This keeps CI fast while you migrate.
-  - Use [`eslint-plugin-oxlint`](https://www.npmjs.com/package/eslint-plugin-oxlint) to disable overlapping ESLint rules while running both.
+  - Use [`eslint-plugin-oxlint`](https://npmx.dev/package/eslint-plugin-oxlint) to disable overlapping ESLint rules while running both.
   - You can - and should - also use [`@oxlint/migrate`](https://github.com/oxc-project/oxlint-migrate) for this approach as well.
 
 ## What Oxlint supports

--- a/src/docs/guide/usage/linter/ci.md
+++ b/src/docs/guide/usage/linter/ci.md
@@ -136,8 +136,8 @@ Replace `v0.0.0` with the latest version.
 
 ### Unplugin
 
-Unplugin is supported via a [third-party package](https://www.npmjs.com/package/unplugin-oxlint)
+Unplugin is supported via a [third-party package](https://npmx.dev/package/unplugin-oxlint)
 
 ### Vite plugin
 
-A Vite plugin is supported via a [third-party package](https://www.npmjs.com/package/vite-plugin-oxlint)
+A Vite plugin is supported via a [third-party package](https://npmx.dev/package/vite-plugin-oxlint)

--- a/src/docs/guide/usage/linter/migrate-from-eslint.md
+++ b/src/docs/guide/usage/linter/migrate-from-eslint.md
@@ -18,7 +18,7 @@ When migrating, expect the following:
 
 ## Migrating from an ESLint flat config
 
-If your project uses an ESLint v9/v10 flat config (e.g. `eslint.config.js` or `eslint.config.mjs`), you can migrate automatically using [`@oxlint/migrate`](https://www.npmjs.com/package/@oxlint/migrate).
+If your project uses an ESLint v9/v10 flat config (e.g. `eslint.config.js` or `eslint.config.mjs`), you can migrate automatically using [`@oxlint/migrate`](https://npmx.dev/package/@oxlint/migrate).
 
 ### Run the migration tool
 
@@ -114,7 +114,7 @@ Long-term - once remaining important rules have been added in Oxlint - we strong
 
 If your project uses ESLint v8.x with legacy config files (such as `.eslintrc.js` or `.eslintrc.json`), they cannot be migrated automatically by `@oxlint/migrate`.
 
-In some cases, you can [migrate them automatically to an ESLint flat config with `@eslint/migrate-config`](https://www.npmjs.com/package/@eslint/migrate-config) first, and _then_ to Oxlint using `@oxlint/migrate`.
+In some cases, you can [migrate them automatically to an ESLint flat config with `@eslint/migrate-config`](https://npmx.dev/package/@eslint/migrate-config) first, and _then_ to Oxlint using `@oxlint/migrate`.
 
 The "legacy" ESLint v8.x configuration file shape maps closely to Oxlint’s config format, so for simple setups most rules and options can be translated directly.
 

--- a/src/docs/guide/usage/minifier.md
+++ b/src/docs/guide/usage/minifier.md
@@ -44,5 +44,5 @@ Rust usage example can be found [here](https://github.com/oxc-project/oxc/blob/m
 <!-- Links -->
 
 [url-oxc-crate]: https://docs.rs/oxc
-[url-oxc-minify-npm]: https://www.npmjs.com/package/oxc-minify
+[url-oxc-minify-npm]: https://npmx.dev/package/oxc-minify
 [url-rolldown]: https://rolldown.rs

--- a/src/docs/guide/usage/parser.md
+++ b/src/docs/guide/usage/parser.md
@@ -34,7 +34,7 @@ Rust usage example can be found [here](https://github.com/oxc-project/oxc/blob/m
 
 After parsing and transforming, you can print code.
 
-Here's a direct example using [esrap](https://www.npmjs.com/package/esrap) _(`parse` in reverse!)_:
+Here's a direct example using [esrap](https://npmx.dev/package/esrap) _(`parse` in reverse!)_:
 
 ```js
 import { print } from "esrap";
@@ -58,4 +58,4 @@ Today, comments are not printed. _It will be supported thanks to [oxc-parser #13
 [url-oxc-crate]: https://docs.rs/oxc
 [url-oxc-ast-crate]: https://docs.rs/oxc_ast
 [url-oxc-parser-crate]: https://docs.rs/oxc_parser
-[url-oxc-parser-npm]: https://www.npmjs.com/package/oxc-parser
+[url-oxc-parser-npm]: https://npmx.dev/package/oxc-parser

--- a/src/docs/guide/usage/resolver.md
+++ b/src/docs/guide/usage/resolver.md
@@ -33,5 +33,5 @@ See [https://crates.io/crates/oxc_resolver][url-oxc-resolver-crate] and its docu
 
 [url-oxc-resolver-crate]: https://crates.io/crates/oxc_resolver
 [url-oxc-resolver-docs]: https://docs.rs/oxc_resolver
-[url-oxc-resolver-npm]: https://www.npmjs.com/package/oxc-resolver
+[url-oxc-resolver-npm]: https://npmx.dev/package/oxc-resolver
 [url-enhanced-resolve]: https://github.com/webpack/enhanced-resolve

--- a/src/docs/guide/usage/transformer.md
+++ b/src/docs/guide/usage/transformer.md
@@ -30,4 +30,4 @@ Rust usage example can be found [here](https://github.com/oxc-project/oxc/blob/m
 <!-- Links -->
 
 [url-oxc-crate]: https://docs.rs/oxc
-[url-oxc-transform-npm]: https://www.npmjs.com/package/oxc-transform
+[url-oxc-transform-npm]: https://npmx.dev/package/oxc-transform


### PR DESCRIPTION
## Summary
- replace npm package links from npmjs.com to https://npmx.dev
- only update documentation files