### PR TITLE
docs: map more npm package GitHub links to npmx.dev

### DIFF
--- a/src/blog/2024-05-04-import-plugin-alpha.md
+++ b/src/blog/2024-05-04-import-plugin-alpha.md
@@ -7,14 +7,14 @@ authors:
 
 <AppBlogPostHeader />
 
-We are excited to announce an alpha release for `oxlint --import-plugin`, a port of [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import).
+We are excited to announce an alpha release for `oxlint --import-plugin`, a port of [`eslint-plugin-import`](https://npmx.dev/package/eslint-plugin-import).
 
 This port aims to resolve all known issues associated with `eslint-plugin-import`:
 
 - Performance - execution time exceeding one minute when certain rules are enabled
 - Dependency size - 188 dependencies totaling 30M
 - Backwards compatibility - the necessity to [support Node.js v4.0.0](https://github.com/import-js/eslint-plugin-import/pull/2447#issuecomment-1117384140)
-- Dependency compatibility - the need to replace it with [`eslint-plugin-import-x`](https://github.com/un-ts/eslint-plugin-import-x)
+- Dependency compatibility - the need to replace it with [`eslint-plugin-import-x`](https://npmx.dev/package/eslint-plugin-import-x)
 - [Upgrading to ESLint v9](https://github.com/import-js/eslint-plugin-import/issues/2948)
 
 ## What's in the release?

--- a/src/blog/2024-09-29-transformer-alpha.md
+++ b/src/blog/2024-09-29-transformer-alpha.md
@@ -59,7 +59,7 @@ await fs.writeFile("out.js", transformed.code);
 await fs.writeFile("out.d.ts", transformed.declaration);
 ```
 
-### [`unplugin-isolated-decl`](https://github.com/unplugin/unplugin-isolated-decl)
+### [`unplugin-isolated-decl`](https://npmx.dev/package/unplugin-isolated-decl)
 
 `vue-macros` [uses](https://github.com/vue-macros/vue-macros/blob/4247c7ba9189c630111e058245ce1412c8da9229/tsup.config.ts#L10) `unplugin-isolated-decl` as the integration tool for its esbuild plugin.
 

--- a/src/blog/2025-06-10-oxlint-stable.md
+++ b/src/blog/2025-06-10-oxlint-stable.md
@@ -82,7 +82,7 @@ Each source file is linted with the nearest applicable configuration, and you ca
 You can also extend shared configs to keep teams consistent.
 
 For projects already using ESLint, [oxlint-migrate](https://github.com/oxc-project/oxlint-migrate) can be used to migrate an existing ESLint flat-config file to Oxlint.
-Additionally, [eslint-plugin-oxlint](https://github.com/oxc-project/eslint-plugin-oxlint) can disable overlapping ESLint rules while both linters are used together.
+Additionally, [eslint-plugin-oxlint](https://npmx.dev/package/eslint-plugin-oxlint) can disable overlapping ESLint rules while both linters are used together.
 It is recommended to run `oxlint && eslint` to benefit from Oxlint's faster feedback cycle.
 
 For more detailed instructions on how to use Oxlint and integrate it with your project or editor, check out the [installation guide](https://oxc.rs/docs/guide/usage/linter).

--- a/src/docs/guide/projects.md
+++ b/src/docs/guide/projects.md
@@ -28,7 +28,7 @@ outline: deep
 - [swc-node](https://github.com/swc-project/swc-node) - Faster ts-node without typecheck
 - [Biome](https://biomejs.dev) - for loading configuration
 - [turborepo](https://github.com/vercel/turborepo/pull/9134) - for `turbo-trace`
-- [dts-resolver](https://github.com/sxzz/dts-resolver) - Resolves TypeScript declaration files for dependencies
+- [dts-resolver](https://npmx.dev/package/dts-resolver) - Resolves TypeScript declaration files for dependencies
 - [codemod](https://github.com/codemod/codemod) - For module resolution in jssg codemods
 
 ## Parser

--- a/src/docs/guide/usage/formatter/ci.md
+++ b/src/docs/guide/usage/formatter/ci.md
@@ -131,7 +131,7 @@ To auto-format staged files, use `oxfmt --no-error-on-unmatched-pattern`. This f
 
 Use `--check` to verify formatting without writing files.
 
-For [lint-staged](https://github.com/lint-staged/lint-staged), add to `package.json`:
+For [lint-staged](https://npmx.dev/package/lint-staged), add to `package.json`:
 
 ```json [package.json]
 {

--- a/src/docs/guide/usage/linter/ci.md
+++ b/src/docs/guide/usage/linter/ci.md
@@ -105,7 +105,7 @@ You should ensure type-aware rules are enabled if you want to use them, and cons
 
 ### lint-staged
 
-For JS/TS projects using [lint-staged](https://github.com/lint-staged/lint-staged), you can set up oxlint to run as a pre-commit hook as follows:
+For JS/TS projects using [lint-staged](https://npmx.dev/package/lint-staged), you can set up oxlint to run as a pre-commit hook as follows:
 
 ```json [package.json]
 {

--- a/src/docs/guide/usage/linter/migrate-from-eslint.md
+++ b/src/docs/guide/usage/linter/migrate-from-eslint.md
@@ -100,7 +100,7 @@ oxlint && eslint
 
 ### Disabling overlapping rules in ESLint
 
-You can use [`eslint-plugin-oxlint`](https://github.com/oxc-project/eslint-plugin-oxlint) to disable ESLint rules that are already handled by Oxlint:
+You can use [`eslint-plugin-oxlint`](https://npmx.dev/package/eslint-plugin-oxlint) to disable ESLint rules that are already handled by Oxlint:
 
 ```bash
 npm install --save-dev eslint-plugin-oxlint

--- a/src/docs/guide/usage/linter/multi-file-analysis.md
+++ b/src/docs/guide/usage/linter/multi-file-analysis.md
@@ -10,7 +10,7 @@ Multi-file analysis allows rules to use project-wide information, such as the mo
 ## Performance and architecture
 
 ESLint evaluates rules per file and does not provide a built-in project graph. Plugins such as
-[`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import) must rebuild module resolution and the module graph outside of ESLint’s core. Projects report the original `import/no-cycle` rule taking tens of seconds, or - on larger repositories - over a minute.
+[`eslint-plugin-import`](https://npmx.dev/package/eslint-plugin-import) must rebuild module resolution and the module graph outside of ESLint’s core. Projects report the original `import/no-cycle` rule taking tens of seconds, or - on larger repositories - over a minute.
 
 Oxlint implements multi-file analysis in the core engine. It lints files and builds the module graph in parallel, shares parsing and resolution across rules, and typically completes comparable `import/no-cycle` checks in a few seconds.
 

--- a/src/docs/guide/usage/linter/quickstart.md
+++ b/src/docs/guide/usage/linter/quickstart.md
@@ -98,7 +98,7 @@ If `PATH` is omitted, Oxlint lints the current working directory.
 
 ## Common workflows
 
-### Pre-commit with [lint-staged](https://github.com/lint-staged/lint-staged)
+### Pre-commit with [lint-staged](https://npmx.dev/package/lint-staged)
 
 ::: code-group
 

--- a/src/docs/guide/usage/linter/versioning.md
+++ b/src/docs/guide/usage/linter/versioning.md
@@ -57,7 +57,7 @@ Add the snippet below to your Renovate config to let it keep Oxlint automaticall
 }
 ```
 
-If you use [eslint-plugin-oxlint](https://github.com/oxc-project/eslint-plugin-oxlint), ensure that it is also updated alongside Oxlint to avoid compatibility issues.
+If you use [eslint-plugin-oxlint](https://npmx.dev/package/eslint-plugin-oxlint), ensure that it is also updated alongside Oxlint to avoid compatibility issues.
 
 ## With Dependabot
 
@@ -83,4 +83,4 @@ updates:
     open-pull-requests-limit: 1 # one PR at a time
 ```
 
-If you use [eslint-plugin-oxlint](https://github.com/oxc-project/eslint-plugin-oxlint), ensure that it is also updated alongside Oxlint to avoid compatibility issues.
+If you use [eslint-plugin-oxlint](https://npmx.dev/package/eslint-plugin-oxlint), ensure that it is also updated alongside Oxlint to avoid compatibility issues.

--- a/src/docs/guide/usage/minifier.md
+++ b/src/docs/guide/usage/minifier.md
@@ -39,7 +39,7 @@ Rust usage example can be found [here](https://github.com/oxc-project/oxc/blob/m
 
 ## Integrations
 
-- [`unplugin-oxc`](https://github.com/unplugin/unplugin-oxc)
+- [`unplugin-oxc`](https://npmx.dev/package/unplugin-oxc)
 
 <!-- Links -->
 

--- a/src/docs/guide/usage/parser.md
+++ b/src/docs/guide/usage/parser.md
@@ -14,7 +14,7 @@ This is production ready.
 - 3x faster than swc parser ([benchmark][url-benchmark]).
 - Parses `.js(x)` and `.ts(x)`.
 - Passes all parser tests from Test262 and 99% from Babel and TypeScript.
-- Returns ESM information directly, no need for [`es-module-lexer`](https://github.com/guybedford/es-module-lexer).
+- Returns ESM information directly, no need for [`es-module-lexer`](https://npmx.dev/package/es-module-lexer).
 - [✅ works with checker.ts](https://x.com/robpalmer2/status/1805502964435505559)
 
 ## Installation

--- a/src/docs/guide/usage/transformer.md
+++ b/src/docs/guide/usage/transformer.md
@@ -24,8 +24,8 @@ Rust usage example can be found [here](https://github.com/oxc-project/oxc/blob/m
 
 ## Integrations
 
-- [`unplugin-oxc`](https://github.com/unplugin/unplugin-oxc)
-- [`unplugin-isolated-decl`](https://github.com/unplugin/unplugin-isolated-decl)
+- [`unplugin-oxc`](https://npmx.dev/package/unplugin-oxc)
+- [`unplugin-isolated-decl`](https://npmx.dev/package/unplugin-isolated-decl)
 
 <!-- Links -->
 


### PR DESCRIPTION
## Summary
- Convert GitHub repository links to npmx.dev for packages that are primarily referenced as npm packages: `eslint-plugin-oxlint`, `unplugin-oxc`, `unplugin-isolated-decl`, `lint-staged`, `eslint-plugin-import`, `eslint-plugin-import-x`, `es-module-lexer`, `dts-resolver`
- Follows up on #930, covering links that were GitHub repo URLs rather than npmjs.com URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)