### PR TITLE
docs: add oxc-webpack-loader to transformer integrations

### DIFF
--- a/src/docs/guide/usage/transformer.md
+++ b/src/docs/guide/usage/transformer.md
@@ -26,6 +26,7 @@ Rust usage example can be found [here](https://github.com/oxc-project/oxc/blob/m
 
 - [`unplugin-oxc`](https://npmx.dev/package/unplugin-oxc)
 - [`unplugin-isolated-decl`](https://npmx.dev/package/unplugin-isolated-decl)
+- [`oxc-webpack-loader`](https://npmx.dev/package/oxc-webpack-loader)
 
 <!-- Links -->
 


### PR DESCRIPTION
## Summary
- Add [`oxc-webpack-loader`](https://npmx.dev/package/oxc-webpack-loader) to the transformer integrations list

🤖 Generated with [Claude Code](https://claude.com/claude-code)