### PR TITLE
feat: add markdown-it task lists

### DIFF
--- a/.vitepress/config/index.ts
+++ b/.vitepress/config/index.ts
@@ -5,6 +5,7 @@ import { rssConfig } from "./rss";
 import { sharedConfig } from "./shared";
 
 import { extendConfig } from "@voidzero-dev/vitepress-theme/config";
+import taskLists from "markdown-it-task-lists";
 
 export default extendConfig(
   defineConfig({
@@ -13,6 +14,11 @@ export default extendConfig(
     head: [...sharedConfig.head!, ...rssConfig.head!],
     locales: {
       ...enConfig,
+    },
+    markdown: {
+      config(md) {
+        md.use(taskLists);
+      },
     },
   }),
 );

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "knip": "^5.78.0",
     "lint-staged": "16.2.7",
     "markdown-it-container": "^4.0.0",
+    "markdown-it-task-lists": "^2.1.1",
     "oxc-minify": "^0.115.0",
     "oxfmt": "^0.35.0",
     "oxlint": "^1.35.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       markdown-it-container:
         specifier: ^4.0.0
         version: 4.0.0
+      markdown-it-task-lists:
+        specifier: ^2.1.1
+        version: 2.1.1
       oxc-minify:
         specifier: ^0.115.0
         version: 0.115.0
@@ -1724,6 +1727,9 @@ packages:
 
   markdown-it-container@4.0.0:
     resolution: {integrity: sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw==}
+
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -3539,6 +3545,8 @@ snapshots:
   mark.js@8.11.1: {}
 
   markdown-it-container@4.0.0: {}
+
+  markdown-it-task-lists@2.1.1: {}
 
   markdown-it@14.1.0:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
       "@data/*": ["./.vitepress/data/*"]
     }
   },
-  "include": ["src/**/*", ".vitepress/**/*"],
+  "include": ["src/**/*", ".vitepress/**/*", "types/**/*.d.ts"],
   "exclude": ["node_modules", "build", ".vitepress/cache"]
 }

--- a/types/markdown-it-task-lists.d.ts
+++ b/types/markdown-it-task-lists.d.ts
@@ -1,0 +1,13 @@
+declare module "markdown-it-task-lists" {
+  import type { PluginWithOptions } from "markdown-it";
+
+  export interface MarkdownItTaskListOptions {
+    enabled?: boolean;
+    label?: boolean;
+    labelAfter?: boolean;
+  }
+
+  const markdownItTaskLists: PluginWithOptions<MarkdownItTaskListOptions>;
+
+  export default markdownItTaskLists;
+}


### PR DESCRIPTION
add [markdown-it-task-list](https://npmx.dev/package/markdown-it-task-lists) to make task lists look better

e.g. for https://oxc.rs/docs/contribute/formatter.html

before:
<img width="309" height="267" alt="image" src="https://github.com/user-attachments/assets/c8b0777a-bfba-4595-89a2-bd8f664b2e59" />

after:
<img width="285" height="242" alt="image" src="https://github.com/user-attachments/assets/6717f7d6-d824-4548-9023-04ca434e509e" />

