### PR TITLE
oxfmt: Prepare for v0.36 release

### DIFF
--- a/src/docs/guide/usage/formatter/embedded-formatting.md
+++ b/src/docs/guide/usage/formatter/embedded-formatting.md
@@ -32,6 +32,28 @@ const styles = css`
 `;
 ```
 
+GraphQL inside a tagged template literal:
+
+```js
+const query = gql`
+  query {
+    user {
+      id
+      name
+    }
+  }
+`;
+
+const query2 = graphql(`
+  query {
+    user {
+      id
+      name
+    }
+  }
+`);
+```
+
 HTML inside a tagged template literal:
 
 ```js

--- a/src/docs/guide/usage/formatter/ignore-comments.md
+++ b/src/docs/guide/usage/formatter/ignore-comments.md
@@ -17,11 +17,29 @@ const x = () => { return 2; };
 ```
 <!-- prettier-ignore-end -->
 
-For non-JS files, use `prettier-ignore` comment. See also Prettier's [ignore documentation](https://prettier.io/docs/ignore#html).
+For JS-in-Vue, use `oxfmt-ignore` inside the `<script>` tag:
+
+<!-- prettier-ignore-start -->
+```vue
+<script>
+// oxfmt-ignore
+const a    = 42;
+</script>
+```
+<!-- prettier-ignore-end -->
+
+Trailing ignore comments are also supported:
+
+<!-- prettier-ignore-start -->
+```js
+const a    = 42; // oxfmt-ignore
+```
+<!-- prettier-ignore-end -->
+
+For other files and non-JS parts of Vue files (e.g., `<template>`, `<style>`), use `prettier-ignore` comment. See also Prettier's [ignore documentation](https://prettier.io/docs/ignore#html).
 
 Currently, TOML files do not support ignore comments.
 
 ## Prettier compatibility
 
 - `prettier-ignore` comment is also supported
-- Trailing ignore comments in JS/TS files are not supported for performance reasons


### PR DESCRIPTION
closes: #949
- gql-in-js
- js-in-vue
- Trailing ignore comments