### PR TITLE
docs: remove release-stage wording from adoption docs

### DIFF
--- a/src/docs/contribute/introduction.md
+++ b/src/docs/contribute/introduction.md
@@ -59,7 +59,7 @@ Oxc is organized into several crates:
 - **`oxc_linter`**: Fast linting engine with 650+ rules
 - **`oxc_transformer`**: TypeScript and JSX transformation
 - **`oxc_minifier`**: JavaScript minification (in development)
-- **`oxc_formatter`**: Code formatting, compatible with Prettier (in alpha)
+- **`oxc_formatter`**: Code formatting, compatible with Prettier
 
 ### Your First Contribution
 

--- a/src/docs/guide/usage/formatter/migrate-from-prettier.md
+++ b/src/docs/guide/usage/formatter/migrate-from-prettier.md
@@ -2,10 +2,6 @@
 
 This guide covers migrating from Prettier to Oxfmt.
 
-:::warning
-Oxfmt is in beta and may not suit particularly complex setups.
-:::
-
 ## Quick start
 
 For simple setups, migrate with a single command:

--- a/src/docs/guide/usage/linter/plugins.md
+++ b/src/docs/guide/usage/linter/plugins.md
@@ -83,23 +83,23 @@ Only default plugins support being disabled. Non-default plugins can simply be o
 
 This table lists the built-in plugins and where they come from.
 
-| Plugin name  | Default | Source                                                                                                                                                           |
-| ------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eslint`     | Yes     | ESLint core rules                                                                                                                                                |
-| `typescript` | Yes     | TypeScript rules from typescript-eslint (aka `@typescript-eslint/plugin`). Type-aware rules are available in alpha using [the type-aware mode](./type-aware.md). |
-| `unicorn`    | Yes     | eslint-plugin-unicorn                                                                                                                                            |
-| `react`      | No      | eslint-plugin-react and eslint-plugin-react-hooks                                                                                                                |
-| `react-perf` | No      | eslint-plugin-react-perf                                                                                                                                         |
-| `nextjs`     | No      | @next/eslint-plugin-next                                                                                                                                         |
-| `oxc`        | Yes     | Oxc-specific rules and selected rules ported from deepscan                                                                                                       |
-| `import`     | No      | eslint-plugin-import (also equivalent to eslint-plugin-import-x)                                                                                                 |
-| `jsdoc`      | No      | eslint-plugin-jsdoc                                                                                                                                              |
-| `jsx-a11y`   | No      | eslint-plugin-jsx-a11y                                                                                                                                           |
-| `node`       | No      | eslint-plugin-n                                                                                                                                                  |
-| `promise`    | No      | eslint-plugin-promise                                                                                                                                            |
-| `jest`       | No      | eslint-plugin-jest                                                                                                                                               |
-| `vitest`     | No      | @vitest/eslint-plugin aka eslint-plugin-vitest                                                                                                                   |
-| `vue`        | No      | eslint-plugin-vue rules that work with script tags                                                                                                               |
+| Plugin name  | Default | Source                                                                                                                                                  |
+| ------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eslint`     | Yes     | ESLint core rules                                                                                                                                       |
+| `typescript` | Yes     | TypeScript rules from typescript-eslint (aka `@typescript-eslint/plugin`). Type-aware rules are available using [the type-aware mode](./type-aware.md). |
+| `unicorn`    | Yes     | eslint-plugin-unicorn                                                                                                                                   |
+| `react`      | No      | eslint-plugin-react and eslint-plugin-react-hooks                                                                                                       |
+| `react-perf` | No      | eslint-plugin-react-perf                                                                                                                                |
+| `nextjs`     | No      | @next/eslint-plugin-next                                                                                                                                |
+| `oxc`        | Yes     | Oxc-specific rules and selected rules ported from deepscan                                                                                              |
+| `import`     | No      | eslint-plugin-import (also equivalent to eslint-plugin-import-x)                                                                                        |
+| `jsdoc`      | No      | eslint-plugin-jsdoc                                                                                                                                     |
+| `jsx-a11y`   | No      | eslint-plugin-jsx-a11y                                                                                                                                  |
+| `node`       | No      | eslint-plugin-n                                                                                                                                         |
+| `promise`    | No      | eslint-plugin-promise                                                                                                                                   |
+| `jest`       | No      | eslint-plugin-jest                                                                                                                                      |
+| `vitest`     | No      | @vitest/eslint-plugin aka eslint-plugin-vitest                                                                                                          |
+| `vue`        | No      | eslint-plugin-vue rules that work with script tags                                                                                                      |
 
 For the current status of rule coverage, see the linter [product plan issue](https://github.com/oxc-project/oxc/issues/481).
 

--- a/src/docs/guide/usage/linter/type-aware.md
+++ b/src/docs/guide/usage/linter/type-aware.md
@@ -7,7 +7,7 @@ description: Linting with type information.
 
 Type-aware linting enables rules that rely on TypeScript’s type system, such as detecting unhandled promises or unsafe assignments. In Oxlint, type-aware linting is provided by [`tsgolint`](https://github.com/oxc-project/tsgolint) and integrated into the Oxlint CLI and configuration system.
 
-This feature is currently **alpha**. Rule coverage, performance, and compatibility continue to improve.
+Rule coverage, performance, and compatibility continue to improve.
 
 ## Overview
 
@@ -186,7 +186,7 @@ See the [TypeScript migration guide](https://github.com/microsoft/TypeScript/iss
 
 ## Stability notes
 
-Type-aware linting is **alpha**:
+Type-aware linting:
 
 - Rule coverage is incomplete
 - Very large codebases may encounter high memory usage

--- a/src/docs/guide/usage/linter/versioning.md
+++ b/src/docs/guide/usage/linter/versioning.md
@@ -24,7 +24,7 @@ What's considered a **non-breaking** change:
 
 ## Features Not Subject to Semver
 
-The following features are **experimental** and are not subject to semantic versioning. They may introduce breaking changes at any time, even in patch or minor releases:
+The following features are not subject to semantic versioning. They may introduce breaking changes at any time, even in patch or minor releases:
 
 - **JavaScript custom plugins** - The plugin API and behavior may change without notice.
 - **Type-aware linting** - Type-aware rules and their behavior may change as this feature evolves.

--- a/src/docs/guide/usage/minifier.md
+++ b/src/docs/guide/usage/minifier.md
@@ -1,7 +1,6 @@
 # Minifier
 
 ::: tip
-`oxc-minify` is currently in alpha and may still have bugs.
 We recommend thoroughly testing its output before deploying to production environments.
 :::
 

--- a/src/docs/guide/usage/transformer/isolated-declarations.md
+++ b/src/docs/guide/usage/transformer/isolated-declarations.md
@@ -1,6 +1,6 @@
 # Isolated Declarations Emit
 
-Oxc transformer supports emitting TypeScript declarations without using the TypeScript compiler for projects with [isolated declarations](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#isolated-declarations) enabled.
+Oxc transformer supports emitting TypeScript declarations without using the TypeScript compiler for projects with [isolated declarations](https://www.typescriptlang.org/tsconfig/#isolatedDeclarations) enabled.
 
 ## Example
 


### PR DESCRIPTION
## Summary
- remove alpha/beta/experimental wording from selected docs pages
- remove warning/status copy that could block adoption messaging
- keep technical caveats where needed and update one TypeScript docs link

## Files
- src/docs/contribute/introduction.md
- src/docs/guide/usage/minifier.md
- src/docs/guide/usage/formatter/migrate-from-prettier.md
- src/docs/guide/usage/linter/plugins.md
- src/docs/guide/usage/linter/type-aware.md
- src/docs/guide/usage/linter/versioning.md
- src/docs/guide/usage/transformer/isolated-declarations.md