### PR TITLE
docs(formatter): update Prettier conformance claim to 100%

### DIFF
--- a/src/docs/guide/usage/formatter.md
+++ b/src/docs/guide/usage/formatter.md
@@ -41,7 +41,7 @@ The `oxfmt` CLI behaves similarly to Prettier by default, allowing adoption with
 
 Oxfmt matches Prettier’s JavaScript formatting. When migrating from recent versions of Prettier, formatting differences should not occur; any differences are considered bugs.
 
-Oxfmt currently passes approximately 95% of Prettier's JavaScript and TypeScript test suite. The remaining cases are niche scenarios, and we work with the Prettier team to converge on formatting over time.
+Oxfmt now passes 100% of Prettier's JavaScript and TypeScript conformance tests. For any remaining formatting inconsistencies, we have [reported them to the Prettier team](https://github.com/oxc-project/oxc/issues/18717) and are collaborating to converge on expected behavior.
 
 No additional dependencies or configuration needed.
 


### PR DESCRIPTION
## Summary
- Update the Oxfmt conformance statement in formatter usage docs from 95% to 100%.
- Align wording with the latest Oxfmt beta blog.
- Add a link to the tracked Prettier convergence issue: [oxc-project/oxc#18717](https://github.com/oxc-project/oxc/issues/18717).

## Testing
- Docs-only change (no runtime tests).