### PR TITLE
Rephrase linter.md's ruleset section to emphasize compatibility

### DIFF
--- a/src/docs/guide/usage/linter.md
+++ b/src/docs/guide/usage/linter.md
@@ -42,7 +42,7 @@ To make migration simple, Oxlint includes [more than {{ ruleCountRounded }} rule
 
 - ESLint core rules
 - TypeScript rules (including type-aware rules)
-- Popular plugins such as React, Jest, Unicorn, and jsx-a11y
+- Popular plugins such as React, Jest, Vitest, Import, Unicorn, and jsx-a11y
 - Custom [JS plugins](/docs/guide/usage/linter/js-plugins) compatible with the ESLint plugin ecosystem
 
 This breadth makes migration straightforward without sacrificing rule coverage. And tooling has been built [to migrate your entire linter config for you](/docs/guide/usage/linter/migrate-from-eslint).


### PR DESCRIPTION
Up to Boshen on whether to merge this, but the previous page didn't really mention compatibility, which is probably _the_ biggest advantage that Oxlint has for existing projects using ESLint. I've updated the ruleset section to emphasize that more.

I think it may even be worth putting the compatibility section above correctness. 

Also include a direct link in that section, to make it clear how easy it is to migrate.