### PR TITLE
Document migration skills

### DIFF
--- a/src/docs/guide/usage/formatter/migrate-from-prettier.md
+++ b/src/docs/guide/usage/formatter/migrate-from-prettier.md
@@ -26,6 +26,16 @@ $ bun add -D oxfmt@latest && bunx oxfmt --migrate=prettier && bunx oxfmt
 
 :::
 
+## Migrate with Skills
+
+You can migrate interactively using the [`migrate-oxfmt`](https://skills.sh/oxc-project/oxc/migrate-oxfmt) skill:
+
+```bash
+npx skills add https://github.com/oxc-project/oxc --skill migrate-oxfmt
+```
+
+Once installed, run `/migrate-oxfmt` and the agent will walk you through the full migration.
+
 ## Before you migrate
 
 Oxfmt is compatible with Prettier v3.8 for many configurations.

--- a/src/docs/guide/usage/linter/migrate-from-eslint.md
+++ b/src/docs/guide/usage/linter/migrate-from-eslint.md
@@ -16,6 +16,16 @@ When migrating, expect the following:
 - Oxlint is designed for incremental adoption; a full migration is not required upfront
 - Oxlint's JS Plugins allow usage of ESLint plugins that are not implemented natively by Oxlint
 
+## Migrate with Skills
+
+You can migrate interactively using the [`migrate-oxlint`](https://skills.sh/oxc-project/oxc/migrate-oxlint) skill:
+
+```bash
+npx skills add https://github.com/oxc-project/oxc --skill migrate-oxlint
+```
+
+Once installed, run `/migrate-oxlint` and the agent will walk you through the full migration.
+
 ## Migrating from an ESLint flat config
 
 If your project uses an ESLint v9/v10 flat config (e.g. `eslint.config.js` or `eslint.config.mjs`), you can migrate automatically using [`@oxlint/migrate`](https://npmx.dev/package/@oxlint/migrate).


### PR DESCRIPTION
## Summary
- Add "Migrate with Skills" sections to the oxlint and oxfmt migration pages
- Links to the [`migrate-oxlint`](https://skills.sh/oxc-project/oxc/migrate-oxlint) and [`migrate-oxfmt`](https://skills.sh/oxc-project/oxc/migrate-oxfmt) skills

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)