### PR TITLE
docs: Note the configuration option for reporting unused directives in the Oxlint config file.

### DIFF
--- a/src/docs/guide/usage/linter/ignore-comments.md
+++ b/src/docs/guide/usage/linter/ignore-comments.md
@@ -84,3 +84,28 @@ oxlint --report-unused-disable-directives-severity error
 ```
 
 Only one of these options can be used at a time.
+
+This can also be set in the Oxlint configuration file:
+
+::: code-group
+
+```jsonc [.oxlintrc.json]
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "options": {
+    "reportUnusedDisableDirectives": "error", // or "off" or "warn"
+  },
+}
+```
+
+```ts [oxlint.config.ts]
+import { defineConfig } from "oxlint";
+
+export default defineConfig({
+  options: {
+    reportUnusedDisableDirectives: "error", // or "off" or "warn"
+  },
+});
+```
+
+:::


### PR DESCRIPTION
<img width="733" height="343" alt="Screenshot 2026-03-11 at 7 03 50 PM" src="https://github.com/user-attachments/assets/22921821-3220-470f-8e01-2bea7a2eb200" />

<img width="760" height="381" alt="Screenshot 2026-03-11 at 7 03 53 PM" src="https://github.com/user-attachments/assets/46706d59-d7ba-40ff-b2c8-dec8d9b61e88" />
