### PR TITLE
docs(linter): Fix config example file.

### DIFF
--- a/src/docs/guide/usage/linter/generated-config.md
+++ b/src/docs/guide/usage/linter/generated-config.md
@@ -57,33 +57,32 @@ Example
 import { defineConfig } from "oxlint";
 
 export default defineConfig({
-plugins: ["import", "typescript", "unicorn"],
-env: {
-"browser": true
-},
-globals: {
-"foo": "readonly"
-},
-settings: {
-react: {
-version: "18.2.0"
-},
-custom: { option: true }
-},
-rules: {
-"eqeqeq": "warn",
-"import/no-cycle": "error",
-"react/self-closing-comp": ["error", { "html": false }]
-},
-overrides: [
-{
-files: ["*.test.ts", "*.spec.ts"],
-rules: {
-"@typescript-eslint/no-explicit-any": "off"
-}
-}
-]
-}
+  plugins: ["import", "typescript", "unicorn"],
+  env: {
+    browser: true,
+  },
+  globals: {
+    foo: "readonly",
+  },
+  settings: {
+    react: {
+      version: "18.2.0",
+    },
+    custom: { option: true },
+  },
+  rules: {
+    eqeqeq: "warn",
+    "import/no-cycle": "error",
+    "react/self-closing-comp": ["error", { html: false }],
+  },
+  overrides: [
+    {
+      files: ["*.test.ts", "*.spec.ts"],
+      rules: {
+        "@typescript-eslint/no-explicit-any": "off",
+      },
+    },
+  ],
 });
 ```
 


### PR DESCRIPTION
It was invalid and thus wasn't being formatted before.

Fixed in oxc with https://github.com/oxc-project/oxc/pull/20253, but I think it's worth porting the fix here ahead of time.