### PR TITLE
docs: add ban policy for repeated low-quality AI PRs

### DIFF
--- a/src/docs/contribute/introduction.md
+++ b/src/docs/contribute/introduction.md
@@ -88,6 +88,7 @@ When using AI tools (including LLMs like ChatGPT, Claude, Copilot, etc.) to cont
 - **Please disclose AI usage** to reduce maintainer fatigue
 - **You are responsible** for all AI-generated issues or PRs you submit
 - **Low-quality or unreviewed AI content will be closed immediately**
+- **Contributors who submit repeated low-quality ("slop") PRs will be banned without prior warning.** Bans may be lifted if you commit to contributing to Oxc in accordance with this policy. You may request an unban via our [Discord](https://discord.gg/9uXCAwqQZW).
 
 We encourage the use of AI tools to assist with development, but all contributions must be thoroughly reviewed and tested by the contributor before submission. AI-generated code should be understood, validated, and adapted to meet Oxc's standards.
 


### PR DESCRIPTION
## Summary
Mirrors oxc-project/oxc@d6a05a7b — adds the ban policy for repeated low-quality ("slop") AI PRs to the AI Usage Policy section of the contributing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)