### PR TITLE
feat(compatibility): highlight clicked footnote and refs

### DIFF
--- a/.vitepress/theme/components/CompatibilityMatrix.vue
+++ b/.vitepress/theme/components/CompatibilityMatrix.vue
@@ -133,7 +133,7 @@ function useCompatData() {
       label: "Partial",
       icon: "mdi:alert-circle",
       colorClass: "bg-[#eab308]",
-      textClass: "text-black",
+      textClass: "text-white",
     },
     none: {
       label: "Not Supported",

--- a/.vitepress/theme/components/CompatibilityMatrix.vue
+++ b/.vitepress/theme/components/CompatibilityMatrix.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { Icon } from "@iconify/vue";
 import { compatData } from "@data/compat";
 import type { Framework, FrameworkCategory, SupportLevel, SupportStatus, Tool } from "@data/compat";
@@ -25,6 +25,37 @@ const { footnoteData, getFootnoteRef, formatFrameworkNames } = useFootnotes(
 );
 
 const activeTooltip = ref<string | null>(null);
+
+const targetedFootnoteId = ref<string | null>(null);
+
+function readTargetFromHash() {
+  if (typeof window === "undefined") return;
+  const hash = window.location.hash.slice(1);
+  targetedFootnoteId.value = hash.startsWith("footnote-") ? hash : null;
+}
+
+function handleFootnoteClick(event: MouseEvent, footnoteId: number) {
+  const id = `footnote-${footnoteId}`;
+  if (targetedFootnoteId.value === id) {
+    targetedFootnoteId.value = null;
+    requestAnimationFrame(() => {
+      targetedFootnoteId.value = id;
+    });
+  } else {
+    targetedFootnoteId.value = id;
+  }
+}
+
+onMounted(() => {
+  readTargetFromHash();
+  window.addEventListener("hashchange", readTargetFromHash);
+});
+
+onBeforeUnmount(() => {
+  if (typeof window !== "undefined") {
+    window.removeEventListener("hashchange", readTargetFromHash);
+  }
+});
 
 const categories: { id: FrameworkCategory | "all"; label: string }[] = [
   { id: "all", label: "All" },
@@ -452,6 +483,7 @@ function useFootnotes(
                     :href="`#footnote-${getFootnoteRef(framework.id, tool.id)!.id}`"
                     class="absolute -top-1 left-full ml-0.5 text-[10px] text-grey hover:text-(--vp-c-brand-1)"
                     :aria-label="`See footnote ${getFootnoteRef(framework.id, tool.id)!.id}`"
+                    @click="handleFootnoteClick($event, getFootnoteRef(framework.id, tool.id)!.id)"
                   >
                     {{ getFootnoteRef(framework.id, tool.id)!.id }}
                   </a>
@@ -499,7 +531,8 @@ function useFootnotes(
             v-for="footnote in toolFootnotes"
             :id="`footnote-${footnote.id}`"
             :key="footnote.id"
-            class="flex gap-2 text-sm text-grey"
+            class="footnote-item flex gap-2 text-sm text-grey"
+            :class="{ 'footnote-item-active': targetedFootnoteId === `footnote-${footnote.id}` }"
           >
             <span class="flex shrink-0 items-center gap-1">
               <a
@@ -534,3 +567,40 @@ function useFootnotes(
     </div>
   </div>
 </template>
+
+<style scoped>
+.footnote-item {
+  scroll-margin-top: calc(var(--vp-nav-height, 64px) + 1rem);
+  padding: 0.5rem;
+  margin: -0.5rem;
+  border-radius: 4px;
+  transition:
+    background-color 0.4s ease,
+    box-shadow 0.4s ease;
+}
+
+.footnote-item:target,
+.footnote-item-active {
+  background-color: var(--vp-c-brand-soft);
+  box-shadow: inset 3px 0 0 var(--vp-c-brand-1);
+  animation: footnote-pulse 1.4s ease-out;
+}
+
+@keyframes footnote-pulse {
+  0% {
+    background-color: color-mix(in srgb, var(--vp-c-brand-1) 35%, transparent);
+  }
+  100% {
+    background-color: var(--vp-c-brand-soft);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .footnote-item,
+  .footnote-item:target,
+  .footnote-item-active {
+    transition: none;
+    animation: none;
+  }
+}
+</style>

--- a/.vitepress/theme/components/CompatibilityMatrix.vue
+++ b/.vitepress/theme/components/CompatibilityMatrix.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
 import { Icon } from "@iconify/vue";
 import { compatData } from "@data/compat";
 import type { Framework, FrameworkCategory, SupportLevel, SupportStatus, Tool } from "@data/compat";
@@ -52,11 +52,11 @@ function readTargetFromHash() {
   setTargetedFootnote(hash.startsWith("footnote-") ? hash : null);
 }
 
-function handleFootnoteClick(event: MouseEvent, footnoteId: number) {
+function handleFootnoteClick(footnoteId: number) {
   const id = `footnote-${footnoteId}`;
   if (targetedFootnoteId.value === id) {
     setTargetedFootnote(null);
-    requestAnimationFrame(() => {
+    nextTick(() => {
       setTargetedFootnote(id);
     });
   } else {
@@ -67,13 +67,24 @@ function handleFootnoteClick(event: MouseEvent, footnoteId: number) {
 function handleBackToRefClick(refIds: string[]) {
   if (refHighlightTimer) clearTimeout(refHighlightTimer);
   highlightedRefIds.value = new Set();
-  requestAnimationFrame(() => {
+  nextTick(() => {
     highlightedRefIds.value = new Set(refIds);
   });
   refHighlightTimer = setTimeout(() => {
     highlightedRefIds.value = new Set();
     refHighlightTimer = null;
   }, 2500);
+}
+
+function getCellContext(framework: Framework, tool: Tool) {
+  const cellData = getCellData(framework.id, tool.id);
+  const footnoteRef = getFootnoteRef(framework.id, tool.id);
+  return {
+    cellData,
+    footnoteRef,
+    tooltipKey: `${framework.id}-${tool.id}`,
+    isRefHighlighted: footnoteRef !== null && highlightedRefIds.value.has(footnoteRef.refId),
+  };
 }
 
 onMounted(() => {
@@ -491,61 +502,57 @@ function useFootnotes(
                 </span>
               </th>
               <td v-for="tool in tools" :key="tool.id" class="px-4 py-3 text-center">
-                <div class="relative inline-flex items-center justify-center">
-                  <button
-                    type="button"
-                    class="status-cell flex size-8 items-center justify-center rounded-lg transition-transform hover:scale-110"
-                    :class="[
-                      getCellData(framework.id, tool.id).config.colorClass,
-                      getFootnoteRef(framework.id, tool.id) &&
-                      highlightedRefIds.has(getFootnoteRef(framework.id, tool.id)!.refId)
-                        ? 'status-cell-active'
-                        : '',
-                    ]"
-                    :aria-label="`${framework.name} ${tool.name}: ${getCellData(framework.id, tool.id).config.label}${getCellData(framework.id, tool.id).status.notes ? ` — ${getCellData(framework.id, tool.id).status.notes}` : ''}`"
-                    @mouseenter="activeTooltip = `${framework.id}-${tool.id}`"
-                    @mouseleave="activeTooltip = null"
-                    @focus="activeTooltip = `${framework.id}-${tool.id}`"
-                    @blur="activeTooltip = null"
-                  >
-                    <Icon
-                      :icon="getCellData(framework.id, tool.id).config.icon"
-                      width="20"
-                      :class="getCellData(framework.id, tool.id).config.textClass"
-                      aria-hidden="true"
-                    />
-                  </button>
-                  <a
-                    v-if="getFootnoteRef(framework.id, tool.id)"
-                    :id="getFootnoteRef(framework.id, tool.id)!.refId"
-                    :href="`#footnote-${getFootnoteRef(framework.id, tool.id)!.id}`"
-                    class="footnote-ref absolute -top-1 left-full ml-0.5 text-[10px] hover:text-(--vp-c-brand-1)"
-                    :class="
-                      highlightedRefIds.has(getFootnoteRef(framework.id, tool.id)!.refId)
-                        ? 'footnote-ref-active text-(--vp-c-brand-1)'
-                        : 'text-grey'
-                    "
-                    :aria-label="`See footnote ${getFootnoteRef(framework.id, tool.id)!.id}`"
-                    @click="handleFootnoteClick($event, getFootnoteRef(framework.id, tool.id)!.id)"
-                  >
-                    {{ getFootnoteRef(framework.id, tool.id)!.id }}
-                  </a>
-                  <!-- Tooltip -->
-                  <div
-                    v-if="
-                      activeTooltip === `${framework.id}-${tool.id}` &&
-                      getCellData(framework.id, tool.id).status.notes
-                    "
-                    class="absolute bottom-full left-1/2 z-50 mb-2 w-48 -translate-x-1/2 rounded-lg bg-primary px-3 py-2 text-center text-xs text-white shadow-lg pointer-events-none dark:border dark:border-nickel dark:bg-slate"
-                    role="tooltip"
-                  >
-                    {{ getCellData(framework.id, tool.id).status.notes }}
+                <template v-for="ctx in [getCellContext(framework, tool)]" :key="ctx.tooltipKey">
+                  <div class="relative inline-flex items-center justify-center">
+                    <button
+                      type="button"
+                      class="status-cell flex size-8 items-center justify-center rounded-lg transition-transform hover:scale-110"
+                      :class="[
+                        ctx.cellData.config.colorClass,
+                        ctx.isRefHighlighted ? 'status-cell-active' : '',
+                      ]"
+                      :aria-label="`${framework.name} ${tool.name}: ${ctx.cellData.config.label}${ctx.cellData.status.notes ? ` — ${ctx.cellData.status.notes}` : ''}`"
+                      @mouseenter="activeTooltip = ctx.tooltipKey"
+                      @mouseleave="activeTooltip = null"
+                      @focus="activeTooltip = ctx.tooltipKey"
+                      @blur="activeTooltip = null"
+                    >
+                      <Icon
+                        :icon="ctx.cellData.config.icon"
+                        width="20"
+                        :class="ctx.cellData.config.textClass"
+                        aria-hidden="true"
+                      />
+                    </button>
+                    <a
+                      v-if="ctx.footnoteRef"
+                      :id="ctx.footnoteRef.refId"
+                      :href="`#footnote-${ctx.footnoteRef.id}`"
+                      class="footnote-ref absolute -top-1 left-full ml-0.5 text-[10px] hover:text-(--vp-c-brand-1)"
+                      :class="
+                        ctx.isRefHighlighted
+                          ? 'footnote-ref-active text-(--vp-c-brand-1)'
+                          : 'text-grey'
+                      "
+                      :aria-label="`See footnote ${ctx.footnoteRef.id}`"
+                      @click="handleFootnoteClick(ctx.footnoteRef.id)"
+                    >
+                      {{ ctx.footnoteRef.id }}
+                    </a>
+                    <!-- Tooltip -->
                     <div
-                      class="absolute -bottom-1 left-1/2 size-2 -translate-x-1/2 rotate-45 bg-primary dark:bg-slate"
-                      aria-hidden="true"
-                    />
+                      v-if="activeTooltip === ctx.tooltipKey && ctx.cellData.status.notes"
+                      class="absolute bottom-full left-1/2 z-50 mb-2 w-48 -translate-x-1/2 rounded-lg bg-primary px-3 py-2 text-center text-xs text-white shadow-lg pointer-events-none dark:border dark:border-nickel dark:bg-slate"
+                      role="tooltip"
+                    >
+                      {{ ctx.cellData.status.notes }}
+                      <div
+                        class="absolute -bottom-1 left-1/2 size-2 -translate-x-1/2 rotate-45 bg-primary dark:bg-slate"
+                        aria-hidden="true"
+                      />
+                    </div>
                   </div>
-                </div>
+                </template>
               </td>
             </tr>
           </template>

--- a/.vitepress/theme/components/CompatibilityMatrix.vue
+++ b/.vitepress/theme/components/CompatibilityMatrix.vue
@@ -27,6 +27,8 @@ const { footnoteData, getFootnoteRef, formatFrameworkNames } = useFootnotes(
 const activeTooltip = ref<string | null>(null);
 
 const targetedFootnoteId = ref<string | null>(null);
+const highlightedRefIds = ref<Set<string>>(new Set());
+let refHighlightTimer: ReturnType<typeof setTimeout> | null = null;
 
 function readTargetFromHash() {
   if (typeof window === "undefined") return;
@@ -46,6 +48,18 @@ function handleFootnoteClick(event: MouseEvent, footnoteId: number) {
   }
 }
 
+function handleBackToRefClick(refIds: string[]) {
+  if (refHighlightTimer) clearTimeout(refHighlightTimer);
+  highlightedRefIds.value = new Set();
+  requestAnimationFrame(() => {
+    highlightedRefIds.value = new Set(refIds);
+  });
+  refHighlightTimer = setTimeout(() => {
+    highlightedRefIds.value = new Set();
+    refHighlightTimer = null;
+  }, 2500);
+}
+
 onMounted(() => {
   readTargetFromHash();
   window.addEventListener("hashchange", readTargetFromHash);
@@ -55,6 +69,7 @@ onBeforeUnmount(() => {
   if (typeof window !== "undefined") {
     window.removeEventListener("hashchange", readTargetFromHash);
   }
+  if (refHighlightTimer) clearTimeout(refHighlightTimer);
 });
 
 const categories: { id: FrameworkCategory | "all"; label: string }[] = [
@@ -462,8 +477,14 @@ function useFootnotes(
                 <div class="relative inline-flex items-center justify-center">
                   <button
                     type="button"
-                    class="flex size-8 items-center justify-center rounded-lg transition-transform hover:scale-110"
-                    :class="getCellData(framework.id, tool.id).config.colorClass"
+                    class="status-cell flex size-8 items-center justify-center rounded-lg transition-transform hover:scale-110"
+                    :class="[
+                      getCellData(framework.id, tool.id).config.colorClass,
+                      getFootnoteRef(framework.id, tool.id) &&
+                      highlightedRefIds.has(getFootnoteRef(framework.id, tool.id)!.refId)
+                        ? 'status-cell-active'
+                        : '',
+                    ]"
                     :aria-label="`${framework.name} ${tool.name}: ${getCellData(framework.id, tool.id).config.label}${getCellData(framework.id, tool.id).status.notes ? ` — ${getCellData(framework.id, tool.id).status.notes}` : ''}`"
                     @mouseenter="activeTooltip = `${framework.id}-${tool.id}`"
                     @mouseleave="activeTooltip = null"
@@ -481,7 +502,12 @@ function useFootnotes(
                     v-if="getFootnoteRef(framework.id, tool.id)"
                     :id="getFootnoteRef(framework.id, tool.id)!.refId"
                     :href="`#footnote-${getFootnoteRef(framework.id, tool.id)!.id}`"
-                    class="absolute -top-1 left-full ml-0.5 text-[10px] text-grey hover:text-(--vp-c-brand-1)"
+                    class="footnote-ref absolute -top-1 left-full ml-0.5 text-[10px] hover:text-(--vp-c-brand-1)"
+                    :class="
+                      highlightedRefIds.has(getFootnoteRef(framework.id, tool.id)!.refId)
+                        ? 'footnote-ref-active text-(--vp-c-brand-1)'
+                        : 'text-grey'
+                    "
                     :aria-label="`See footnote ${getFootnoteRef(framework.id, tool.id)!.id}`"
                     @click="handleFootnoteClick($event, getFootnoteRef(framework.id, tool.id)!.id)"
                   >
@@ -539,6 +565,7 @@ function useFootnotes(
                 :href="`#${footnote.refIds[0]}`"
                 class="text-grey hover:text-(--vp-c-brand-1)"
                 :aria-label="`Back to reference ${footnote.id}`"
+                @click="handleBackToRefClick(footnote.refIds)"
                 >&#8593;</a
               >
               <span class="font-medium text-grey">{{ footnote.id }}.</span>
@@ -595,12 +622,57 @@ function useFootnotes(
   }
 }
 
+.footnote-ref {
+  transition: color 0.3s ease;
+}
+
+.footnote-ref-active {
+  font-weight: 700;
+  animation: footnote-ref-pulse 2.5s ease-out;
+  transform-origin: left center;
+}
+
+.status-cell-active {
+  animation: status-cell-glow 2.5s ease-out;
+}
+
+@keyframes status-cell-glow {
+  0% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+  30% {
+    box-shadow: 0 0 10px 3px var(--vp-c-brand-1);
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
+@keyframes footnote-ref-pulse {
+  0% {
+    transform: scale(1.6);
+    text-shadow: 0 0 6px var(--vp-c-brand-1);
+  }
+  40% {
+    transform: scale(1.2);
+    text-shadow: 0 0 3px var(--vp-c-brand-soft);
+  }
+  100% {
+    transform: scale(1);
+    text-shadow: none;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .footnote-item,
   .footnote-item:target,
-  .footnote-item-active {
+  .footnote-item-active,
+  .footnote-ref,
+  .footnote-ref-active,
+  .status-cell-active {
     transition: none;
     animation: none;
+    transform: none;
   }
 }
 </style>

--- a/.vitepress/theme/components/CompatibilityMatrix.vue
+++ b/.vitepress/theme/components/CompatibilityMatrix.vue
@@ -144,7 +144,7 @@ function useCompatData() {
       label: "Partial",
       icon: "mdi:alert-circle",
       colorClass: "bg-[#eab308]",
-      textClass: "text-white",
+      textClass: "text-black",
     },
     none: {
       label: "Not Supported",

--- a/.vitepress/theme/components/CompatibilityMatrix.vue
+++ b/.vitepress/theme/components/CompatibilityMatrix.vue
@@ -122,6 +122,7 @@ interface StatusConfig {
   icon: string;
   colorClass: string;
   textClass: string;
+  ringClass: string;
 }
 
 interface CellData {
@@ -139,24 +140,28 @@ function useCompatData() {
       icon: "mdi:check-circle",
       colorClass: "bg-[#22c55e]",
       textClass: "text-white",
+      ringClass: "ring-[#22c55e]/60",
     },
     partial: {
       label: "Partial",
       icon: "mdi:alert-circle",
       colorClass: "bg-[#eab308]",
       textClass: "text-black",
+      ringClass: "ring-[#eab308]/60",
     },
     none: {
       label: "Not Supported",
       icon: "mdi:close-circle",
       colorClass: "bg-[#ef4444]",
       textClass: "text-white",
+      ringClass: "ring-[#ef4444]/60",
     },
     "n/a": {
       label: "Out of Scope",
       icon: "mdi:minus-circle",
       colorClass: "bg-[#6b7280]",
       textClass: "text-white",
+      ringClass: "ring-[#6b7280]/60",
     },
   };
 
@@ -506,10 +511,10 @@ function useFootnotes(
                   <div class="relative inline-flex items-center justify-center">
                     <button
                       type="button"
-                      class="status-cell flex size-8 items-center justify-center rounded-lg transition-transform hover:scale-110"
+                      class="flex size-8 items-center justify-center rounded-lg transition-[transform,box-shadow] duration-500 hover:scale-110 motion-reduce:transition-none"
                       :class="[
                         ctx.cellData.config.colorClass,
-                        ctx.isRefHighlighted ? 'status-cell-active' : '',
+                        ctx.isRefHighlighted ? `ring-4 ${ctx.cellData.config.ringClass}` : '',
                       ]"
                       :aria-label="`${framework.name} ${tool.name}: ${ctx.cellData.config.label}${ctx.cellData.status.notes ? ` — ${ctx.cellData.status.notes}` : ''}`"
                       @mouseenter="activeTooltip = ctx.tooltipKey"
@@ -528,10 +533,10 @@ function useFootnotes(
                       v-if="ctx.footnoteRef"
                       :id="ctx.footnoteRef.refId"
                       :href="`#footnote-${ctx.footnoteRef.id}`"
-                      class="footnote-ref absolute -top-1 left-full ml-0.5 text-[10px] hover:text-(--vp-c-brand-1)"
+                      class="absolute -top-1 left-full ml-0.5 origin-left text-[10px] transition-[transform,color] duration-500 hover:text-(--vp-c-brand-1) motion-reduce:transition-none"
                       :class="
                         ctx.isRefHighlighted
-                          ? 'footnote-ref-active text-(--vp-c-brand-1)'
+                          ? 'scale-150 font-bold text-(--vp-c-brand-1) motion-reduce:scale-100'
                           : 'text-grey'
                       "
                       :aria-label="`See footnote ${ctx.footnoteRef.id}`"
@@ -581,8 +586,12 @@ function useFootnotes(
             v-for="footnote in toolFootnotes"
             :id="`footnote-${footnote.id}`"
             :key="footnote.id"
-            class="footnote-item flex gap-2 text-sm text-grey"
-            :class="{ 'footnote-item-active': targetedFootnoteId === `footnote-${footnote.id}` }"
+            class="-m-2 flex gap-2 rounded p-2 text-sm text-grey scroll-mt-[calc(var(--vp-nav-height,64px)+1rem)] transition-[background-color,box-shadow] duration-700 motion-reduce:transition-none"
+            :class="
+              targetedFootnoteId === `footnote-${footnote.id}`
+                ? 'bg-(--vp-c-brand-soft) shadow-[inset_3px_0_0_var(--vp-c-brand-1)]'
+                : ''
+            "
           >
             <span class="flex shrink-0 items-center gap-1">
               <a
@@ -618,87 +627,3 @@ function useFootnotes(
     </div>
   </div>
 </template>
-
-<style scoped>
-.footnote-item {
-  scroll-margin-top: calc(var(--vp-nav-height, 64px) + 1rem);
-  padding: 0.5rem;
-  margin: -0.5rem;
-  border-radius: 4px;
-  transition:
-    background-color 0.4s ease,
-    box-shadow 0.4s ease;
-}
-
-.footnote-item-active {
-  animation: footnote-pulse 1.5s ease-out forwards;
-}
-
-@keyframes footnote-pulse {
-  0% {
-    background-color: color-mix(in srgb, var(--vp-c-brand-1) 35%, transparent);
-    box-shadow: inset 3px 0 0 var(--vp-c-brand-1);
-  }
-  15% {
-    background-color: var(--vp-c-brand-soft);
-    box-shadow: inset 3px 0 0 var(--vp-c-brand-1);
-  }
-  100% {
-    background-color: transparent;
-    box-shadow: inset 3px 0 0 transparent;
-  }
-}
-
-.footnote-ref {
-  transition: color 0.3s ease;
-}
-
-.footnote-ref-active {
-  font-weight: 700;
-  animation: footnote-ref-pulse 2.5s ease-out;
-  transform-origin: left center;
-}
-
-.status-cell-active {
-  animation: status-cell-glow 2.5s ease-out;
-}
-
-@keyframes status-cell-glow {
-  0% {
-    box-shadow: 0 0 0 0 transparent;
-  }
-  30% {
-    box-shadow: 0 0 10px 3px var(--vp-c-brand-1);
-  }
-  100% {
-    box-shadow: 0 0 0 0 transparent;
-  }
-}
-
-@keyframes footnote-ref-pulse {
-  0% {
-    transform: scale(1.6);
-    text-shadow: 0 0 6px var(--vp-c-brand-1);
-  }
-  40% {
-    transform: scale(1.2);
-    text-shadow: 0 0 3px var(--vp-c-brand-soft);
-  }
-  100% {
-    transform: scale(1);
-    text-shadow: none;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .footnote-item,
-  .footnote-item-active,
-  .footnote-ref,
-  .footnote-ref-active,
-  .status-cell-active {
-    transition: none;
-    animation: none;
-    transform: none;
-  }
-}
-</style>

--- a/.vitepress/theme/components/CompatibilityMatrix.vue
+++ b/.vitepress/theme/components/CompatibilityMatrix.vue
@@ -28,23 +28,39 @@ const activeTooltip = ref<string | null>(null);
 
 const targetedFootnoteId = ref<string | null>(null);
 const highlightedRefIds = ref<Set<string>>(new Set());
+let footnoteHighlightTimer: ReturnType<typeof setTimeout> | null = null;
 let refHighlightTimer: ReturnType<typeof setTimeout> | null = null;
+const HIGHLIGHT_MS = 1500;
+
+function setTargetedFootnote(id: string | null) {
+  if (footnoteHighlightTimer) {
+    clearTimeout(footnoteHighlightTimer);
+    footnoteHighlightTimer = null;
+  }
+  targetedFootnoteId.value = id;
+  if (id) {
+    footnoteHighlightTimer = setTimeout(() => {
+      targetedFootnoteId.value = null;
+      footnoteHighlightTimer = null;
+    }, HIGHLIGHT_MS);
+  }
+}
 
 function readTargetFromHash() {
   if (typeof window === "undefined") return;
   const hash = window.location.hash.slice(1);
-  targetedFootnoteId.value = hash.startsWith("footnote-") ? hash : null;
+  setTargetedFootnote(hash.startsWith("footnote-") ? hash : null);
 }
 
 function handleFootnoteClick(event: MouseEvent, footnoteId: number) {
   const id = `footnote-${footnoteId}`;
   if (targetedFootnoteId.value === id) {
-    targetedFootnoteId.value = null;
+    setTargetedFootnote(null);
     requestAnimationFrame(() => {
-      targetedFootnoteId.value = id;
+      setTargetedFootnote(id);
     });
   } else {
-    targetedFootnoteId.value = id;
+    setTargetedFootnote(id);
   }
 }
 
@@ -69,6 +85,7 @@ onBeforeUnmount(() => {
   if (typeof window !== "undefined") {
     window.removeEventListener("hashchange", readTargetFromHash);
   }
+  if (footnoteHighlightTimer) clearTimeout(footnoteHighlightTimer);
   if (refHighlightTimer) clearTimeout(refHighlightTimer);
 });
 
@@ -606,19 +623,22 @@ function useFootnotes(
     box-shadow 0.4s ease;
 }
 
-.footnote-item:target,
 .footnote-item-active {
-  background-color: var(--vp-c-brand-soft);
-  box-shadow: inset 3px 0 0 var(--vp-c-brand-1);
-  animation: footnote-pulse 1.4s ease-out;
+  animation: footnote-pulse 1.5s ease-out forwards;
 }
 
 @keyframes footnote-pulse {
   0% {
     background-color: color-mix(in srgb, var(--vp-c-brand-1) 35%, transparent);
+    box-shadow: inset 3px 0 0 var(--vp-c-brand-1);
+  }
+  15% {
+    background-color: var(--vp-c-brand-soft);
+    box-shadow: inset 3px 0 0 var(--vp-c-brand-1);
   }
   100% {
-    background-color: var(--vp-c-brand-soft);
+    background-color: transparent;
+    box-shadow: inset 3px 0 0 transparent;
   }
 }
 
@@ -665,7 +685,6 @@ function useFootnotes(
 
 @media (prefers-reduced-motion: reduce) {
   .footnote-item,
-  .footnote-item:target,
   .footnote-item-active,
   .footnote-ref,
   .footnote-ref-active,


### PR DESCRIPTION
A few minor changes for the Compatibility page to make it a bit clearer when using the footnotes.

- Updates the footnote link to highlight the footnote being linked for a few seconds before fading away.
- Updates the backlink in the footnote section (the up arrow) to highlight the relevant status icons/footnote number for a few seconds before fading (see screenshot 1)
 
<img width="645" height="718" alt="Screenshot 2026-04-18 at 11 13 47 AM" src="https://github.com/user-attachments/assets/02cbd3ea-b3f1-4db2-85c2-310480002ebb" />

🤖 Generated with [Claude Code](https://claude.com/claude-code), PR description written by me.