### PR TITLE
docs(formatter): add oxfmt.config.ts tabs to config examples

### DIFF
--- a/src/docs/guide/usage/formatter/config.md
+++ b/src/docs/guide/usage/formatter/config.md
@@ -104,6 +104,8 @@ Oxfmt uses only the nearest `.editorconfig` from the current directory:
 
 Use the `overrides` field to apply different formatting options to specific files:
 
+::: code-group
+
 ```json [.oxfmtrc.json]
 {
   "printWidth": 100,
@@ -124,6 +126,31 @@ Use the `overrides` field to apply different formatting options to specific file
   ]
 }
 ```
+
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  printWidth: 100,
+  overrides: [
+    {
+      files: ["*.test.js", "*.spec.ts"],
+      options: {
+        printWidth: 120,
+      },
+    },
+    {
+      files: ["*.md", "*.html"],
+      excludeFiles: ["*.min.js"],
+      options: {
+        tabWidth: 4,
+      },
+    },
+  ],
+});
+```
+
+:::
 
 Each override entry has:
 
@@ -161,11 +188,23 @@ Oxfmt defaults to `printWidth: 100` (Prettier uses 80). Reasons:
 
 To match Prettier's default:
 
+::: code-group
+
 ```json [.oxfmtrc.json]
 {
   "printWidth": 80
 }
 ```
+
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  printWidth: 80,
+});
+```
+
+:::
 
 ## Next steps
 

--- a/src/docs/guide/usage/formatter/embedded-formatting.md
+++ b/src/docs/guide/usage/formatter/embedded-formatting.md
@@ -4,11 +4,23 @@ Formats code embedded in JS/TS files (CSS in template literals, GraphQL in templ
 
 ## Configuration
 
+::: code-group
+
 ```json [.oxfmtrc.json]
 {
   "embeddedLanguageFormatting": "auto"
 }
 ```
+
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  embeddedLanguageFormatting: "auto",
+});
+```
+
+:::
 
 ### Values
 

--- a/src/docs/guide/usage/formatter/ignore-files.md
+++ b/src/docs/guide/usage/formatter/ignore-files.md
@@ -4,13 +4,25 @@ Oxfmt provides several ways to exclude files from formatting.
 
 ## `ignorePatterns`
 
-The recommended way to ignore files. Add to `.oxfmtrc.json`:
+The recommended way to ignore files. Add to your Oxfmt config:
+
+::: code-group
 
 ```json [.oxfmtrc.json]
 {
   "ignorePatterns": ["dist/**", "*.min.js"]
 }
 ```
+
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  ignorePatterns: ["dist/**", "*.min.js"],
+});
+```
+
+:::
 
 - Uses `.gitignore` syntax
 - Paths are resolved relative to the directory containing the Oxfmt config file

--- a/src/docs/guide/usage/formatter/sorting.md
+++ b/src/docs/guide/usage/formatter/sorting.md
@@ -18,6 +18,8 @@ Disabled by default.
 
 The same order as `eslint-plugin-perfectionist/sort-imports` default.
 
+::: code-group
+
 ```json [.oxfmtrc.json]
 {
   "sortImports": {
@@ -34,7 +36,29 @@ The same order as `eslint-plugin-perfectionist/sort-imports` default.
 }
 ```
 
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  sortImports: {
+    groups: [
+      "type-import",
+      ["value-builtin", "value-external"],
+      "type-internal",
+      "value-internal",
+      ["type-parent", "type-sibling", "type-index"],
+      ["value-parent", "value-sibling", "value-index"],
+      "unknown",
+    ],
+  },
+});
+```
+
+:::
+
 Use `"newlinesBetween": false` at the top level to disable newlines between groups, then use `{ "newlinesBetween": true }` within `groups` to insert a newline at a specific point.
+
+::: code-group
 
 ```json [.oxfmtrc.json]
 {
@@ -51,7 +75,28 @@ Use `"newlinesBetween": false` at the top level to disable newlines between grou
 }
 ```
 
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  sortImports: {
+    newlinesBetween: false,
+    groups: [
+      ["value-builtin", "value-external"],
+      ["value-internal", "value-parent", "value-sibling", "value-index"],
+      { newlinesBetween: true },
+      "type-import",
+      "unknown",
+    ],
+  },
+});
+```
+
+:::
+
 Use `customGroups` to define your own groups for matching specific imports. Each custom group has a `groupName` that can be referenced in `groups`. The `elementNamePattern` accepts glob patterns to match import sources.
+
+::: code-group
 
 ```json [.oxfmtrc.json]
 {
@@ -73,6 +118,30 @@ Use `customGroups` to define your own groups for matching specific imports. Each
 }
 ```
 
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  sortImports: {
+    customGroups: [
+      {
+        groupName: "react-libs",
+        elementNamePattern: ["react", "react-**"],
+      },
+    ],
+    groups: [
+      "react-libs",
+      ["value-builtin", "value-external"],
+      "value-internal",
+      ["value-parent", "value-sibling", "value-index"],
+      "unknown",
+    ],
+  },
+});
+```
+
+:::
+
 ## Sort Tailwind CSS classes
 
 Sorts Tailwind utility classes.
@@ -83,6 +152,8 @@ Disabled by default.
 
 ### Example configuration
 
+::: code-group
+
 ```json [.oxfmtrc.json]
 {
   "sortTailwindcss": {
@@ -92,6 +163,20 @@ Disabled by default.
   }
 }
 ```
+
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  sortTailwindcss: {
+    stylesheet: "./path/to/stylesheet.css",
+    functions: ["clsx", "cn"],
+    preserveWhitespace: true,
+  },
+});
+```
+
+:::
 
 Regex patterns for `attributes` and `functions` are not supported.
 
@@ -107,13 +192,27 @@ Enabled by default.
 
 To disable:
 
+::: code-group
+
 ```json [.oxfmtrc.json]
 {
   "sortPackageJson": false
 }
 ```
 
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  sortPackageJson: false,
+});
+```
+
+:::
+
 To sort `scripts` alphabetically:
+
+::: code-group
 
 ```json [.oxfmtrc.json]
 {
@@ -122,3 +221,15 @@ To sort `scripts` alphabetically:
   }
 }
 ```
+
+```ts [oxfmt.config.ts]
+import { defineConfig } from "oxfmt";
+
+export default defineConfig({
+  sortPackageJson: {
+    sortScripts: true,
+  },
+});
+```
+
+:::


### PR DESCRIPTION
Add corresponding `oxfmt.config.ts` examples to the various example configs in the docs.

Generated with Claude Code, reviewed by me.