### PR TITLE
docs(transformer): fix outdated options to match oxc-transform types

### DIFF
--- a/src/docs/guide/usage/transformer.md
+++ b/src/docs/guide/usage/transformer.md
@@ -9,6 +9,38 @@
 - [Replacing global variables.](./transformer/global-variable-replacement)
 - [TypeScript Isolated Declarations Emit without using the TypeScript compiler.](./transformer/isolated-declarations)
 
+## General Options
+
+The `transform` function accepts a filename, source code, and an options object:
+
+```js
+import { transform } from "oxc-transform";
+
+const result = await transform("lib.ts", sourceCode, {
+  // Force the source language. Inferred from filename by default.
+  lang: "tsx", // "js" | "jsx" | "ts" | "tsx" | "dts"
+
+  // Treat the source as script, module, or CommonJS. Inferred by default.
+  sourceType: "module", // "script" | "module" | "commonjs" | "unambiguous"
+
+  // The current working directory. Used to resolve relative paths.
+  cwd: "/path/to/project",
+
+  // Enable source map generation.
+  sourcemap: true,
+
+  // Configure runtime helper strategy.
+  helpers: {
+    mode: "Runtime", // "Runtime" (import from @oxc-project/runtime) or "External" (use global babelHelpers)
+  },
+
+  // See sub-pages for more options:
+  // typescript, jsx, target, assumptions, define, inject, decorator, plugins
+});
+```
+
+The `transform` function is async. A synchronous `transformSync` variant is also available with the same signature.
+
 ## Installation
 
 ### Node.js

--- a/src/docs/guide/usage/transformer/isolated-declarations.md
+++ b/src/docs/guide/usage/transformer/isolated-declarations.md
@@ -36,4 +36,10 @@ const result = await isolatedDeclaration("lib.ts", sourceCode, {
   sourcemap: false,
   stripInternal: false,
 });
+
+console.log(result.code); // the .d.ts content
+console.log(result.map); // the source map (if sourcemap is enabled)
+console.log(result.errors); // parse and transformation errors
 ```
+
+A synchronous `isolatedDeclarationSync` variant is also available with the same signature.

--- a/src/docs/guide/usage/transformer/lowering.md
+++ b/src/docs/guide/usage/transformer/lowering.md
@@ -124,10 +124,10 @@ The following assumptions are supported.
 
 ### `ignoreFunctionLength`
 
-Assume that no code relies on the `.length` property of function objects. When enabled, helpers may introduce default parameter patterns that do not preserve the original function length.
+Assume that no code relies on the `.length` property of function objects.
 
 ::: info Note
-This assumption is currently accepted but has no effect. It is reserved for future use.
+This assumption is not fully implemented yet. In particular, enabling it with object rest/spread currently produces a transform error.
 :::
 
 ### `noDocumentAll`
@@ -136,10 +136,10 @@ Assume that the deprecated `document.all` with its special behavior is not used.
 
 ### `objectRestNoSymbols`
 
-Assume that object rest/spread properties do not include Symbol keys. This allows the compiler to avoid copying Symbol properties when spreading, producing smaller output.
+Assume that object rest/spread properties do not include Symbol keys.
 
 ::: info Note
-This assumption is currently accepted but has no effect. It is reserved for future use.
+This assumption is not fully implemented yet. In particular, enabling it with object rest/spread currently produces a transform error.
 :::
 
 ### `pureGetters`

--- a/src/docs/guide/usage/transformer/lowering.md
+++ b/src/docs/guide/usage/transformer/lowering.md
@@ -118,9 +118,17 @@ const result = await transform("lib.js", "const foo = a ?? b;", {
 
 The following assumptions are supported.
 
+### `ignoreFunctionLength`
+
+Assume that no code relies on the `.length` property of function objects. When enabled, helpers may introduce default parameter patterns that do not preserve the original function length.
+
 ### `noDocumentAll`
 
 Assume that the deprecated `document.all` with its special behavior is not used.
+
+### `objectRestNoSymbols`
+
+Assume that object rest/spread properties do not include Symbol keys. This allows the compiler to avoid copying Symbol properties when spreading, producing smaller output.
 
 ### `pureGetters`
 

--- a/src/docs/guide/usage/transformer/lowering.md
+++ b/src/docs/guide/usage/transformer/lowering.md
@@ -122,6 +122,10 @@ The following assumptions are supported.
 
 Assume that no code relies on the `.length` property of function objects. When enabled, helpers may introduce default parameter patterns that do not preserve the original function length.
 
+::: info Note
+This assumption is currently accepted but has no effect. It is reserved for future use.
+:::
+
 ### `noDocumentAll`
 
 Assume that the deprecated `document.all` with its special behavior is not used.
@@ -129,6 +133,10 @@ Assume that the deprecated `document.all` with its special behavior is not used.
 ### `objectRestNoSymbols`
 
 Assume that object rest/spread properties do not include Symbol keys. This allows the compiler to avoid copying Symbol properties when spreading, producing smaller output.
+
+::: info Note
+This assumption is currently accepted but has no effect. It is reserved for future use.
+:::
 
 ### `pureGetters`
 

--- a/src/docs/guide/usage/transformer/lowering.md
+++ b/src/docs/guide/usage/transformer/lowering.md
@@ -24,11 +24,15 @@ Each target environment is an environment name followed by a version number. The
 
 The values that are supported by [esbuild's target option](https://esbuild.github.io/api/#target) are supported, excluding ES5.
 
+You can pass a single string or an array of strings:
+
 ```js
 import { transform } from "oxc-transform";
 
 const result = await transform("lib.js", "const foo = a ?? b;", {
-  target: ["chrome87", "es2022"],
+  target: "es2020",
+  // or multiple targets:
+  // target: ["chrome87", "es2022"],
 });
 ```
 

--- a/src/docs/guide/usage/transformer/plugins.md
+++ b/src/docs/guide/usage/transformer/plugins.md
@@ -2,6 +2,22 @@
 
 Oxc transformer includes built-in support for popular transformation plugins to improve developer experience and build performance.
 
+## Tagged Template Escape
+
+When enabled, `</script>` sequences inside tagged template literals are escaped to prevent browsers from prematurely closing a surrounding `<script>` tag. This avoids parsing errors and potential XSS vulnerabilities when JavaScript is embedded directly in HTML.
+
+```javascript
+import { transform } from "oxc-transform";
+
+const result = await transform("lib.js", sourceCode, {
+  plugins: {
+    taggedTemplateEscape: true,
+  },
+});
+```
+
+For example, `` foo`</script>` `` is transformed into a helper call where the `</script>` sequence is escaped to `<\/script>`.
+
 ## Styled Components
 
 The styled-components plugin adds comprehensive support for styled-components with server-side rendering, style minification, and enhanced debugging capabilities.

--- a/src/docs/guide/usage/transformer/plugins.md
+++ b/src/docs/guide/usage/transformer/plugins.md
@@ -7,7 +7,7 @@ Oxc transformer includes built-in support for popular transformation plugins to 
 When enabled, `</script>` sequences inside tagged template literals are escaped to prevent browsers from prematurely closing a surrounding `<script>` tag. This avoids parsing errors and potential XSS vulnerabilities when JavaScript is embedded directly in HTML.
 
 ::: tip Recommendation
-This option should always be enabled. Without it, tagged template literals containing `</script>` can break when the output is embedded in HTML `<script>` tags. See [oxc-project/oxc#15306](https://github.com/oxc-project/oxc/issues/15306) for details.
+Enable this option when the transformed output may be embedded directly in HTML `<script>` tags. Without it, tagged template literals containing `</script>` can break when embedded in HTML `<script>` tags. See [oxc-project/oxc#15306](https://github.com/oxc-project/oxc/issues/15306) for details.
 :::
 
 ```javascript

--- a/src/docs/guide/usage/transformer/plugins.md
+++ b/src/docs/guide/usage/transformer/plugins.md
@@ -6,6 +6,10 @@ Oxc transformer includes built-in support for popular transformation plugins to 
 
 When enabled, `</script>` sequences inside tagged template literals are escaped to prevent browsers from prematurely closing a surrounding `<script>` tag. This avoids parsing errors and potential XSS vulnerabilities when JavaScript is embedded directly in HTML.
 
+::: tip Recommendation
+This option should always be enabled. Without it, tagged template literals containing `</script>` can break when the output is embedded in HTML `<script>` tags. See [oxc-project/oxc#15306](https://github.com/oxc-project/oxc/issues/15306) for details.
+:::
+
 ```javascript
 import { transform } from "oxc-transform";
 

--- a/src/docs/guide/usage/transformer/typescript.md
+++ b/src/docs/guide/usage/transformer/typescript.md
@@ -199,7 +199,7 @@ See [JSX transform](./jsx) for more information.
 
 If you are using the [`rewriteRelativeImportExtensions`](https://www.typescriptlang.org/tsconfig/#rewriteRelativeImportExtensions) option in the tsconfig, you can use the `typescript.rewriteImportExtensions` option.
 
-- `"rewrite"` or `true`: rewrites `.ts`, `.tsx`, `.mts`, `.cts` extensions to `.js`, `.jsx`, `.mjs`, `.cjs`.
+- `"rewrite"` or `true`: rewrites `.ts` and `.tsx` to `.js`, `.mts` to `.mjs`, and `.cts` to `.cjs`.
 - `"remove"`: removes `.ts`/`.tsx`/`.mts`/`.cts` extensions entirely.
 - `false` (default): no changes.
 

--- a/src/docs/guide/usage/transformer/typescript.md
+++ b/src/docs/guide/usage/transformer/typescript.md
@@ -13,6 +13,8 @@ const result = await transform("lib.ts", sourceCode, {
     allowNamespaces: true,
     removeClassFieldsWithoutInitializer: false,
     rewriteImportExtensions: false,
+    optimizeConstEnums: false,
+    optimizeEnums: false,
   },
 });
 ```
@@ -57,14 +59,14 @@ const result = await transform("lib.ts", sourceCode, {
 
 Oxc transformer supports transforming legacy decorators. This is called experimental decorators in TypeScript.
 
-If you are using the [`experimentalDecorators`](https://www.typescriptlang.org/tsconfig/#experimentalDecorators) option in the tsconfig, you can use the `decorators.legacy` option.
-If you are using the [`emitDecoratorMetadata`](https://www.typescriptlang.org/tsconfig/#emitDecoratorMetadata) option in the tsconfig, you can use the `decorators.emitDecoratorMetadata` option.
+If you are using the [`experimentalDecorators`](https://www.typescriptlang.org/tsconfig/#experimentalDecorators) option in the tsconfig, you can use the `decorator.legacy` option.
+If you are using the [`emitDecoratorMetadata`](https://www.typescriptlang.org/tsconfig/#emitDecoratorMetadata) option in the tsconfig, you can use the `decorator.emitDecoratorMetadata` option.
 
 ```js
 import { transform } from "oxc-transform";
 
 const result = await transform("lib.ts", sourceCode, {
-  decorators: {
+  decorator: {
     legacy: true,
     emitDecoratorMetadata: true,
   },
@@ -197,14 +199,65 @@ See [JSX transform](./jsx) for more information.
 
 If you are using the [`rewriteImportExtensions`](https://www.typescriptlang.org/tsconfig/#rewriteImportExtensions) option in the tsconfig, you can use the `typescript.rewriteImportExtensions` option.
 
+- `"rewrite"` or `true` — rewrites `.ts`, `.mts`, `.cts` extensions to `.js`, `.mjs`, `.cjs`.
+- `"remove"` — removes `.ts`/`.mts`/`.cts`/`.tsx` extensions entirely.
+- `false` (default) — no changes.
+
 ```js
 import { transform } from "oxc-transform";
 
 const result = await transform("lib.ts", sourceCode, {
   typescript: {
-    rewriteImportExtensions: "rewrite", // or "remove"
+    rewriteImportExtensions: "rewrite", // or "remove", true, false
   },
 });
+```
+
+## Optimize Const Enums
+
+When enabled, const enum values are inlined at usage sites and the enum declaration is removed.
+
+```js
+import { transform } from "oxc-transform";
+
+const result = await transform("lib.ts", sourceCode, {
+  typescript: {
+    optimizeConstEnums: true,
+  },
+});
+```
+
+## Optimize Enums
+
+When enabled, regular (non-const) enum member accesses are inlined at usage sites when all members satisfy const enum constraints (i.e., their values are statically evaluable). Non-exported enum declarations are also removed when all members are evaluable and no references to the enum as a runtime value exist.
+
+```js
+import { transform } from "oxc-transform";
+
+const result = await transform("lib.ts", sourceCode, {
+  typescript: {
+    optimizeEnums: true,
+  },
+});
+```
+
+## Declaration
+
+Generate `.d.ts` declaration files alongside the transform output. The source file must be compliant with all [`isolatedDeclarations`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#isolated-declarations) requirements.
+
+```js
+import { transform } from "oxc-transform";
+
+const result = await transform("lib.ts", sourceCode, {
+  typescript: {
+    declaration: {
+      stripInternal: false,
+    },
+  },
+});
+
+console.log(result.declaration); // the .d.ts content
+console.log(result.declarationMap); // the declaration source map (if sourcemap is enabled)
 ```
 
 ## Caveats

--- a/src/docs/guide/usage/transformer/typescript.md
+++ b/src/docs/guide/usage/transformer/typescript.md
@@ -197,11 +197,11 @@ See [JSX transform](./jsx) for more information.
 
 ## Rewriting import extensions
 
-If you are using the [`rewriteImportExtensions`](https://www.typescriptlang.org/tsconfig/#rewriteImportExtensions) option in the tsconfig, you can use the `typescript.rewriteImportExtensions` option.
+If you are using the [`rewriteRelativeImportExtensions`](https://www.typescriptlang.org/tsconfig/#rewriteRelativeImportExtensions) option in the tsconfig, you can use the `typescript.rewriteImportExtensions` option.
 
-- `"rewrite"` or `true` — rewrites `.ts`, `.mts`, `.cts` extensions to `.js`, `.mjs`, `.cjs`.
-- `"remove"` — removes `.ts`/`.mts`/`.cts`/`.tsx` extensions entirely.
-- `false` (default) — no changes.
+- `"rewrite"` or `true`: rewrites `.ts`, `.tsx`, `.mts`, `.cts` extensions to `.js`, `.jsx`, `.mjs`, `.cjs`.
+- `"remove"`: removes `.ts`/`.tsx`/`.mts`/`.cts` extensions entirely.
+- `false` (default): no changes.
 
 ```js
 import { transform } from "oxc-transform";
@@ -213,9 +213,12 @@ const result = await transform("lib.ts", sourceCode, {
 });
 ```
 
-## Optimize Const Enums
+## Optimize Enums
 
-When enabled, const enum values are inlined at usage sites and the enum declaration is removed.
+Oxc transformer can optimize enums by inlining their member values at usage sites.
+
+- `optimizeConstEnums`: inlines `const enum` values and removes the declaration.
+- `optimizeEnums`: inlines regular (non-const) enum member accesses when all members satisfy const enum constraints (i.e., their values are statically evaluable). Non-exported enum declarations are also removed when all members are evaluable and no references to the enum as a runtime value exist.
 
 ```js
 import { transform } from "oxc-transform";
@@ -223,19 +226,6 @@ import { transform } from "oxc-transform";
 const result = await transform("lib.ts", sourceCode, {
   typescript: {
     optimizeConstEnums: true,
-  },
-});
-```
-
-## Optimize Enums
-
-When enabled, regular (non-const) enum member accesses are inlined at usage sites when all members satisfy const enum constraints (i.e., their values are statically evaluable). Non-exported enum declarations are also removed when all members are evaluable and no references to the enum as a runtime value exist.
-
-```js
-import { transform } from "oxc-transform";
-
-const result = await transform("lib.ts", sourceCode, {
-  typescript: {
     optimizeEnums: true,
   },
 });


### PR DESCRIPTION
## Summary

- add a general transformer options section covering `lang`, `sourceType`, `cwd`, `sourcemap`, `helpers`, and `transformSync`
- document isolated declarations result fields and `isolatedDeclarationSync`
- expand TypeScript docs with `optimizeConstEnums`, `optimizeEnums`, `declaration`, and `rewriteImportExtensions`
- fix incorrect option names and examples such as `decorator` vs `decorators`
- add tagged template escape docs and clarify that it is relevant when transformed output may be embedded directly in HTML `<script>` tags
- document additional compiler assumptions and note that `ignoreFunctionLength` and `objectRestNoSymbols` are not fully implemented yet for object rest/spread
- fix the `rewriteImportExtensions` mapping to note that `.ts` and `.tsx` rewrite to `.js`

Cross-checked against `oxc-transform` type definitions and upstream implementation/fixtures where the docs call out specific behavior.

## Test plan

- [ ] `vp check` (blocked locally: `vite-plus` could not be resolved from `vite.config.ts` in this workspace)
- [ ] Review each changed page renders correctly
- [x] Cross-check option names, types, and result fields against `oxc-transform` `index.d.ts`
- [x] Cross-check behavior-specific notes against upstream implementation and conformance fixtures