### PR TITLE
feat: add focus-visible styles to home page buttons and code blocks.

### DIFF
--- a/.vitepress/theme/styles.css
+++ b/.vitepress/theme/styles.css
@@ -15,6 +15,11 @@
   --color-brand: #0d6a73;
 }
 
+.button:focus-visible {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 2px;
+}
+
 /*  Override unusual GitHub avatars */
 .VPTeamMembersItem {
   --member-item-avatar-size-small: 64px;

--- a/.vitepress/theme/styles.css
+++ b/.vitepress/theme/styles.css
@@ -20,6 +20,11 @@
   outline-offset: 2px;
 }
 
+.vp-code-group .tabs input:focus-visible + label {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 2px;
+}
+
 /*  Override unusual GitHub avatars */
 .VPTeamMembersItem {
   --member-item-avatar-size-small: 64px;

--- a/.vitepress/theme/styles.css
+++ b/.vitepress/theme/styles.css
@@ -20,7 +20,7 @@
   outline-offset: 2px;
 }
 
-.vp-code-group .tabs input:focus-visible + label {
+.vp-code-group:has(.tabs input:focus-visible) {
   outline: 2px solid var(--color-brand);
   outline-offset: 2px;
 }


### PR DESCRIPTION
Adds keyboard-focus outlines to the Get Started, View on GitHub, and Usage Guide buttons on the home page so they have a visible indicator when navigating with keyboard.

It's a bit hard to see when not actively using the page, but basically the "Get Started" button has an additional focus outline now when focused, same thing for other buttons that lacked focus styles here:

<img width="574" height="680" alt="Screenshot 2026-04-25 at 1 25 58 PM" src="https://github.com/user-attachments/assets/50a7f15e-3dee-4748-b461-3e4dc15b364e" />

The code blocks with tabs have also been updated accordingly, to make it easier to tell when the code block is focused and tabs can be interacted-with:

<img width="744" height="300" alt="Screenshot 2026-04-25 at 1 34 37 PM" src="https://github.com/user-attachments/assets/13a7ff43-72c6-44e7-a77f-85e04b05d015" />

This was generated with Claude Code, it may be worth making this change universally in the VoidZero theme, but I don't have any ability to do that, so that'd be up to someone else to do :)