### PR TITLE
fix: Update test command for linter rules

### DIFF
--- a/src/docs/contribute/linter/adding-rules.md
+++ b/src/docs/contribute/linter/adding-rules.md
@@ -341,7 +341,7 @@ and
 To test your rule whenever you make a change, run:
 
 ```bash
-just watch "test -p oxc_linter -- rule-name"
+just watch "cargo test -p oxc_linter -- rule-name"
 ```
 
 Or to just test it once, run:


### PR DESCRIPTION
Running the command `just watch "test -p oxc_linter -- rule-name"` threw an error for me. I guess this was an accident, since it's missing  **cargo**: `just watch cargo test ...`

Corrected the command in this PR.