### PR TITLE
docs: remove unreleased `ruleCustomization` feature

### DIFF
--- a/src/docs/guide/usage/linter/generated-lsp-config.md
+++ b/src/docs/guide/usage/linter/generated-lsp-config.md
@@ -65,24 +65,6 @@ type: `"safe_fix" | "safe_fix_or_suggestion" | "dangerous_fix" | "dangerous_fix_
 
 What kind of fixes to generate for code actions.
 
-## rulesCustomization
-
-type: `Record<string, object>`
-
-Customization for individual rules, allows to override the linter's diagnostics and autofix.
-Example of lowering the severity of "no-unused-vars" rule to "hint" and disabling autofix for it:
-
-```json
-{
-  "rulesCustomization": {
-    "no-unused-vars": {
-      "severity": "hint",
-      "autofix": false
-    }
-  }
-}
-```
-
 ## run
 
 type: `"onSave" | "onType"`


### PR DESCRIPTION
the website docs were re-generated after the ruleCustomization feature was merged, but after the release was cut, this cause it to erronously show in the docs.