### PR TITLE
Prettier migration guide: mention ignore comments

### DIFF
--- a/src/docs/guide/usage/formatter/migrate-from-prettier.md
+++ b/src/docs/guide/usage/formatter/migrate-from-prettier.md
@@ -205,3 +205,9 @@ Add the reformatting commit SHA to `.git-blame-ignore-revs` to hide it from `git
 ### Replace `.prettierignore` with `"ignorePatterns"`
 
 If you no longer use Prettier, you can optionally move its contents from `.prettierignore` to `"ignorePatterns"` in your Oxfmt config. Note that `.prettierignore` applies globally, while `ignorePatterns` is scoped to the config file it belongs to. In a [nested config](./config#create-a-config-file) setup, this may change which files are ignored. See [Ignore files](/docs/guide/usage/formatter/ignore-files) for more information.
+
+### Update `// prettier-ignore` comments
+
+Oxfmt supports `// prettier-ignore` comments, but also supports `// oxfmt-ignore` comments.
+
+However, `// oxfmt-ignore` will only work for JS and TS files.

--- a/src/docs/guide/usage/formatter/migrate-from-prettier.md
+++ b/src/docs/guide/usage/formatter/migrate-from-prettier.md
@@ -210,4 +210,4 @@ If you no longer use Prettier, you can optionally move its contents from `.prett
 
 Oxfmt supports `// prettier-ignore` comments, but also supports `// oxfmt-ignore` comments.
 
-However, `// oxfmt-ignore` will only work for JS and TS files.
+However, `// oxfmt-ignore` will only work for JS and TS files. See [Inline ignore comments](/docs/guide/usage/formatter/ignore-comments) for more information.


### PR DESCRIPTION
Not sure how to include this exactly, but I though it's worth mentioning `// prettier-ignore` and `// oxfmt-ignore` comments here

As far as I understand oxfmt delegates to other tools like prettier as a fallback for certain kind of files, and `// prettier-ignore` comments remains relevant for them, for example `.mdx` files only support `// prettier-ignore`
