### PR TITLE
docs: add a link to the explanation of rule categories

### DIFF
--- a/src/docs/guide/usage/linter/rules.md
+++ b/src/docs/guide/usage/linter/rules.md
@@ -26,6 +26,12 @@ The progress of all rule implementations is tracked [here](https://github.com/ox
 - Rules turned on by default: {{ defaultCount }}
 - Rules with fixes available: {{ fixableCount }}
 
+::: details About rule categories
+
+Categories group rules by intent and can be enabled together in configuration. See [Enable groups of rules with categories](/docs/guide/usage/linter/config.html#enable-groups-of-rules-with-categories) for examples.
+
+:::
+
 ::: details Legend for 'Fixable?' column
 
 - 🛠️: an auto-fix is available for this rule

--- a/src/docs/guide/usage/linter/rules.md
+++ b/src/docs/guide/usage/linter/rules.md
@@ -26,7 +26,7 @@ The progress of all rule implementations is tracked [here](https://github.com/ox
 - Rules turned on by default: {{ defaultCount }}
 - Rules with fixes available: {{ fixableCount }}
 
-::: details About rule categories
+::: details Rule categories
 
 Categories group rules by intent and can be enabled together in configuration. See [Enable groups of rules with categories](/docs/guide/usage/linter/config.html#enable-groups-of-rules-with-categories) for details.
 

--- a/src/docs/guide/usage/linter/rules.md
+++ b/src/docs/guide/usage/linter/rules.md
@@ -28,7 +28,7 @@ The progress of all rule implementations is tracked [here](https://github.com/ox
 
 ::: details About rule categories
 
-Categories group rules by intent and can be enabled together in configuration. See [Enable groups of rules with categories](/docs/guide/usage/linter/config.html#enable-groups-of-rules-with-categories) for examples.
+Categories group rules by intent and can be enabled together in configuration. See [Enable groups of rules with categories](/docs/guide/usage/linter/config.html#enable-groups-of-rules-with-categories) for details.
 
 :::
 


### PR DESCRIPTION
When configuring rules for `oxlint`, I frequently visit the [rules reference page](https://oxc.rs/docs/guide/usage/linter/rules.html).
However, I often find myself needing to look up the definition of "rule categories" in the [configuration docs](https://oxc.rs/docs/guide/usage/linter/config.html#enable-groups-of-rules-with-categories).

Adding a direct link will improve navigation and save time.


<img width="813" height="545" alt="スクリーンショット 2026-05-12 1 50 25" src="https://github.com/user-attachments/assets/6075875a-7c9b-4e4e-949f-e6306b6bf2e5" />

