### PR TITLE
chore: update packageManager to pnpm 11.0.4

### DIFF
--- a/.vitepress/theme/components/RulesTable.vue
+++ b/.vitepress/theme/components/RulesTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 // Import the generated rules data
 import rules from "@data/rules.json" with { type: "json" };
 import fixEmoji from "./utils/fixEmoji";
@@ -40,7 +40,9 @@ const toggleSort = (column: SortColumn) => {
 
 const resetFilters = () => {
   // Workaround for VoidZero base button focus style issue
-  (window.document.activeElement as HTMLButtonElement)?.blur();
+  if (typeof window !== "undefined") {
+    (window.document.activeElement as HTMLButtonElement)?.blur();
+  }
 
   categoryFilter.value = "all";
   scopeFilter.value = "all";
@@ -82,11 +84,17 @@ const handleInitialQueryParams = () => {
   }
 };
 
-handleInitialQueryParams();
+onMounted(() => {
+  handleInitialQueryParams();
+});
 
 watch(
   [sortColumn, sortDirection, categoryFilter, scopeFilter, includeTypeAware, hasFixOnly],
   () => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
     const params = new URLSearchParams(location.search);
     params.set("sort", sortColumn.value);
     params.set("dir", sortDirection.value);

--- a/.vitepress/theme/components/RulesTable.vue
+++ b/.vitepress/theme/components/RulesTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 // Import the generated rules data
 import rules from "@data/rules.json" with { type: "json" };
 import fixEmoji from "./utils/fixEmoji";
@@ -40,9 +40,7 @@ const toggleSort = (column: SortColumn) => {
 
 const resetFilters = () => {
   // Workaround for VoidZero base button focus style issue
-  if (typeof window !== "undefined") {
-    (window.document.activeElement as HTMLButtonElement)?.blur();
-  }
+  (window.document.activeElement as HTMLButtonElement)?.blur();
 
   categoryFilter.value = "all";
   scopeFilter.value = "all";
@@ -84,17 +82,11 @@ const handleInitialQueryParams = () => {
   }
 };
 
-onMounted(() => {
-  handleInitialQueryParams();
-});
+handleInitialQueryParams();
 
 watch(
   [sortColumn, sortDirection, categoryFilter, scopeFilter, includeTypeAware, hasFixOnly],
   () => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
     const params = new URLSearchParams(location.search);
     params.set("sort", sortColumn.value);
     params.set("dir", sortDirection.value);

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "vitepress-plugin-llms": "^1.12.0",
     "vue": "^3.5.30"
   },
-  "packageManager": "pnpm@11.0.4"
+  "packageManager": "pnpm@10.33.2"
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "vitepress-plugin-llms": "^1.12.0",
     "vue": "^3.5.30"
   },
-  "packageManager": "pnpm@10.33.2"
+  "packageManager": "pnpm@11.0.4"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vitepress dev",
-    "prebuild": "vp run sponsors",
+    "prebuild": "pnpm run sponsors",
     "build": "vitepress build",
     "preview": "vitepress preview",
     "lint": "vp lint --deny-warnings",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 packages:
   - "!sponsors"
+allowBuilds:
+  esbuild: true
+  vue-demi: true
 catalog:
   vite-plus: ^0.1.13
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,5 @@
 packages:
   - "!sponsors"
-allowBuilds:
-  esbuild: true
-  vue-demi: true
 catalog:
   vite-plus: ^0.1.13
 overrides:


### PR DESCRIPTION
## Summary
- update the pnpm package manager pin to `pnpm@11.0.4`
- add missing pnpm package manager metadata where needed
- keep lockfiles unchanged to avoid unrelated dependency updates