### PR TITLE
ci: use vp run void deploy instead of pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,6 @@ jobs:
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1.10.0
         with:
           cache: ${{ github.ref_name == 'main' }}
-      - run: pnpm void deploy
+      - run: vp run void deploy
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}


### PR DESCRIPTION
## Summary

- The `Deploy to Void` job in CI failed with `pnpm: command not found` because `voidzero-dev/setup-vp` installs `vp` but not `pnpm` ([failing run](https://github.com/oxc-project/website/actions/runs/26015677114/job/76465181831)).
- Switch the deploy step to `vp run void deploy`, which runs the `void` script defined in `package.json` and forwards `deploy` as an argument — consistent with the other CI steps that use `vp run <script>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)