### PR TITLE
docs: remove Netlify Status badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Netlify Status](https://api.netlify.com/api/v1/badges/6cedad30-edc5-4e4b-b9a1-991721587e70/deploy-status)](https://app.netlify.com/sites/oxc-project/deploys)
-
 # Oxc Website
 
 - Netlify: [oxc.rs](https://oxc.rs)


### PR DESCRIPTION
## Summary

- The Netlify Status badge at the top of the README points at the old Netlify deploy and is no longer relevant. Removed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)