### PR TITLE
ci: set VOID_PROJECT for Void deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,4 @@ jobs:
       - run: vp run void deploy
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
+          VOID_PROJECT: oxc-project


### PR DESCRIPTION
## Summary

The previous Void deploy failed with `No project specified. Set `VOID_PROJECT`, pass `--project <slug>`, or commit `.void/project.json`` (see [run 26016063994](https://github.com/oxc-project/website/actions/runs/26016063994/job/76466315118)).

`.void/` is gitignored — it contains a `dev-trigger-token` that shouldn't be checked in — so `.void/project.json` never reaches CI. Pass the slug via the `VOID_PROJECT` env var on the deploy step instead.