### PR TITLE
ci: rename Void project to oxc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,4 +50,4 @@ jobs:
       - run: vp run void deploy
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
-          VOID_PROJECT: oxc-project
+          VOID_PROJECT: oxc

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Oxc Website
 
 - Netlify: [oxc.rs](https://oxc.rs)
-- Void: [oxc-project.void.app](https://oxc-project.void.app)
+- Void: [oxc.void.app](http://oxc.void.app/)
 
 ### Contributing
 


### PR DESCRIPTION
## Summary
- Set `VOID_PROJECT` to `oxc` in the deploy workflow
- Update the README's Void link to `http://oxc.void.app/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)