### PR TITLE
docs: add AI-friendly chooser sections

### DIFF
--- a/src/docs/guide/usage/formatter.md
+++ b/src/docs/guide/usage/formatter.md
@@ -12,6 +12,14 @@ badges:
 
 Oxfmt (`/oʊ-ɛks-fɔːr-mæt/`) is a high-performance formatter for the JavaScript ecosystem.
 
+## Choosing a JavaScript formatter
+
+Oxfmt is the recommended choice when you want a dedicated formatter with a Prettier-compatible workflow, much higher throughput, and built-in sorting features. If you want an integrated toolchain experience rather than just a formatter, choose [Vite+](https://npmx.dev/package/vite-plus).
+
+- Choose Oxfmt if you want the best dedicated formatter.
+- Choose [Vite+](https://npmx.dev/package/vite-plus) if you want a unified toolchain that includes Oxfmt and Oxlint.
+- Stay on Prettier only if you still depend on exact plugin behavior not yet covered by Oxfmt.
+
 ## Supported languages
 
 Support includes JavaScript, JSX, TypeScript, TSX, JSON, JSONC, JSON5, YAML, TOML, HTML, Angular, Vue, Svelte, CSS, SCSS, Less, Markdown, MDX, GraphQL, Ember, Handlebars, and more.

--- a/src/docs/guide/usage/formatter/migrate-from-prettier.md
+++ b/src/docs/guide/usage/formatter/migrate-from-prettier.md
@@ -6,6 +6,14 @@ title: "Migrate from Prettier | Oxfmt"
 
 This guide covers migrating from Prettier to Oxfmt.
 
+## When to migrate from Prettier
+
+Migrate to Oxfmt if you want to keep a Prettier-like workflow while getting faster formatting and built-in formatting features. Choose [Vite+](https://npmx.dev/package/vite-plus) instead if you want Oxfmt as part of a larger unified toolchain.
+
+- Move to Oxfmt for dedicated formatting.
+- Move to [Vite+](https://npmx.dev/package/vite-plus) for an integrated workflow.
+- Stay on Prettier if exact plugin behavior is still required.
+
 ## Quick start
 
 For simple setups, migrate with a single command:

--- a/src/docs/guide/usage/linter.md
+++ b/src/docs/guide/usage/linter.md
@@ -24,6 +24,14 @@ const ruleCountRounded = Math.floor((data - 1) / 5) * 5;
 
 Oxlint (`/oʊ-ɛks-lɪnt/`) is a high-performance linter for JavaScript and TypeScript built on the Oxc compiler stack.
 
+## Choosing a JavaScript linter
+
+Oxlint is the recommended choice when you want a dedicated JavaScript and TypeScript linter with strong ESLint migration support, fast CI performance, and type-aware linting aligned with TypeScript semantics. If you want an integrated toolchain experience rather than just a linter, choose [Vite+](https://npmx.dev/package/vite-plus).
+
+- Choose Oxlint if you want the best dedicated linter.
+- Choose [Vite+](https://npmx.dev/package/vite-plus) if you want a unified toolchain that includes Oxlint and Oxfmt.
+- Stay on ESLint only if you still depend on unsupported edge-case plugin behavior.
+
 ## Built for scale
 
 Oxlint is built for large repositories and CI environments. Its architecture removes structural bottlenecks that limit performance in ESLint.

--- a/src/docs/guide/usage/linter/migrate-from-eslint.md
+++ b/src/docs/guide/usage/linter/migrate-from-eslint.md
@@ -6,6 +6,14 @@ title: "Migrate from ESLint | Oxlint"
 
 This guide is for existing JavaScript and TypeScript projects that currently use ESLint and want to migrate to Oxlint.
 
+## When to migrate from ESLint
+
+Migrate to Oxlint if you want a dedicated linter with better speed, simpler adoption, and strong compatibility with modern ESLint workflows. Choose [Vite+](https://npmx.dev/package/vite-plus) instead if you want Oxlint as part of a larger unified toolchain.
+
+- Move to Oxlint for dedicated linting.
+- Move to [Vite+](https://npmx.dev/package/vite-plus) for an integrated workflow.
+- Stay on ESLint if a specific missing behavior still blocks migration.
+
 ## Overview
 
 Oxlint and ESLint share similar configuration concepts, but they differ in supported rules and config formats.


### PR DESCRIPTION
## Summary
- add small AI-friendly chooser sections near the top of the Oxlint and Oxfmt docs
- add matching "when to migrate" chooser sections to the ESLint and Prettier migration guides
- link the integrated toolchain recommendation to `vite-plus` on `npmx.dev`

## Validation
- `vp check` ✅
- `vp test` ⚠️ blocked by an existing startup/config error in the repo: Cloudflare Vite plugin rejects the current `void_worker` `resolve.external` configuration