### PR TITLE
fix: apply rules table query params after hydration

### DIFF
--- a/.vitepress/theme/components/RulesTable.vue
+++ b/.vitepress/theme/components/RulesTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 // Import the generated rules data
 import rules from "@data/rules.json" with { type: "json" };
 import fixEmoji from "./utils/fixEmoji";
@@ -93,9 +93,7 @@ const handleInitialQueryParams = () => {
   }
 };
 
-if (!import.meta.env.SSR) {
-  handleInitialQueryParams();
-}
+onMounted(handleInitialQueryParams);
 
 watch(
   [sortColumn, sortDirection, categoryFilter, scopeFilter, includeTypeAware, hasFixOnly],


### PR DESCRIPTION
## Summary

- Apply the rules table query parameters after client mount instead of during client setup.
- Avoid SSR/client hydration mismatch that could leave filtered row labels paired with stale `href` attributes from the unfiltered table order.

## Issue Screenshot

![Bad rules links with scope query params](https://github.com/user-attachments/assets/8f5ea0df-5f05-473f-a71e-1dbde6ef11bc)



fixes #1129