### PR TITLE
feat(components): render upstream rule docs link in RuleReferences

### DIFF
--- a/.vitepress/theme/components/RuleReferences.vue
+++ b/.vitepress/theme/components/RuleReferences.vue
@@ -7,6 +7,7 @@ const { frontmatter } = useData();
 
 const rule = computed(() => frontmatter.value.rule as string);
 const hasTsgolint = computed(() => frontmatter.value.type_aware === true);
+const upstream = computed(() => frontmatter.value.upstream as string | undefined);
 
 function toSnakeCase(str: string): string {
   return str.replace(/-/g, "_");
@@ -42,6 +43,9 @@ const playgroundUrl = computed(() => {
   <ul>
     <li>
       <a :href="source" target="_blank" rel="noreferrer">Rule Source</a>
+    </li>
+    <li v-if="upstream">
+      <a :href="upstream" target="_blank" rel="noreferrer">Upstream rule docs</a>
     </li>
     <li v-if="hasTsgolint">
       <a :href="tsgolintSource" target="_blank" rel="noreferrer">Rule Source (tsgolint)</a>


### PR DESCRIPTION
## Summary

Adds an `upstream` prop on the `<RuleReferences />` component. When set, an "Upstream rule docs" link is rendered at the top of the references list, pointing at the original ESLint plugin's docs page for the rule.

Used by [oxc-project/oxc#22769](https://github.com/oxc-project/oxc/pull/22769), which writes the upstream URL on every auto-generated rule docs page (skipped for native oxc rules and unknown plugins).

After both PRs land, each rule page on oxc.rs will surface the upstream rule docs alongside the existing "Rule Source" / "Playground" links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)