### PR TITLE
chore(deps): add VoidZero deps to `minimumReleaseAgeExclude`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,25 @@ peerDependencyRules:
     vite: "*"
     vitest: "*"
 verifyDepsBeforeRun: install
+minimumReleaseAgeExclude:
+  - "@oxc-minify/*"
+  - "@oxc-parser/*"
+  - "@oxc-project/*"
+  - "@oxfmt/*"
+  - "@oxlint-tsgolint/*"
+  - "@oxlint/*"
+  - "@rolldown/*"
+  - "@tsdown/*"
+  - "@vitejs/devtools"
+  - "@vitest/*"
+  - "@voidzero-dev/*"
+  - oxc-minify
+  - oxc-parser
+  - oxfmt
+  - oxlint
+  - oxlint-tsgolint
+  - rolldown
+  - tsdown
+  - vite
+  - vite-plus
+  - vitest


### PR DESCRIPTION
## Summary

Adds `minimumReleaseAgeExclude` entries for the Oxc/VoidZero toolchain packages used by this website repo, mirroring the fix from oxc-project/oxc#22899.

This includes the website-specific `oxc-minify` and `@oxc-minify/*` entries needed for Renovate PR #1146, whose Netlify deploy failed while installing newly released Oxc minifier packages.
