### PR TITLE
docs: formalize migrate-with-skills sections in migration guides

### DIFF
--- a/src/docs/guide/usage/formatter/migrate-from-prettier.md
+++ b/src/docs/guide/usage/formatter/migrate-from-prettier.md
@@ -40,13 +40,13 @@ $ bun add -D oxfmt@latest && bunx oxfmt --migrate=prettier && bunx oxfmt
 
 ## Migrate with Skills
 
-You can migrate interactively using the [`migrate-oxfmt`](https://skills.sh/oxc-project/oxc/migrate-oxfmt) skill:
+The [`migrate-oxfmt`](https://skills.sh/oxc-project/oxc/migrate-oxfmt) skill provides an interactive, agent-guided migration. Install it into your coding agent:
 
 ```bash
 npx skills add https://github.com/oxc-project/oxc --skill migrate-oxfmt
 ```
 
-Once installed, run `/migrate-oxfmt` and the agent will walk you through the full migration.
+Once installed, run `/migrate-oxfmt` to perform the migration.
 
 ## Before you migrate
 

--- a/src/docs/guide/usage/linter/migrate-from-eslint.md
+++ b/src/docs/guide/usage/linter/migrate-from-eslint.md
@@ -30,13 +30,13 @@ When migrating, expect the following:
 
 ## Migrate with Skills
 
-You can migrate interactively using the [`migrate-oxlint`](https://skills.sh/oxc-project/oxc/migrate-oxlint) skill:
+The [`migrate-oxlint`](https://skills.sh/oxc-project/oxc/migrate-oxlint) skill provides an interactive, agent-guided migration. Install it into your coding agent:
 
 ```bash
 npx skills add https://github.com/oxc-project/oxc --skill migrate-oxlint
 ```
 
-Once installed, run `/migrate-oxlint` and the agent will walk you through the full migration.
+Once installed, run `/migrate-oxlint` to perform the migration.
 
 ## Migrating from an ESLint flat config
 


### PR DESCRIPTION
Rewords the **Migrate with Skills** sections in the linter and formatter migration guides to use more formal documentation language (drops the second-person "you can…" / "the agent will walk you through…" phrasing).

- `linter/migrate-from-eslint.md`
- `formatter/migrate-from-prettier.md`

The migration skills are intentionally kept in the migration guides rather than the "Getting started" sections, so the earlier Getting-started tips were dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
