### PR TITLE
fix: apply _headers in void deploy so the logo serves CORP

### DIFF
--- a/void.json
+++ b/void.json
@@ -5,5 +5,6 @@
   "inference": {
     "appType": "static",
     "outputDir": "build"
-  }
+  },
+  "routing": {}
 }


### PR DESCRIPTION
## Summary

The `_headers` rule that serves `Cross-Origin-Resource-Policy: cross-origin` on `/logo-without-border.svg` was never being applied. Void's static deploy only parses `_headers` when a `routing` block exists in `void.json`; without it, the logo is served with no CORP header.

As a result, cross-origin pages that set `Cross-Origin-Embedder-Policy: require-corp` (e.g. the oxc playground) can't load the logo as a favicon:

```
GET https://oxc.rs/logo-without-border.svg
net::ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep
```

Adding an empty `routing: {}` makes the deploy parse `build/_headers` and serve the existing CORP rule. (Confirmed: oxc.rs currently returns the logo with no `cross-origin-resource-policy` header.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)