### PR TITLE
chore: remove redundant voidPlugin() from vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from "vite-plus";
-import { voidPlugin } from "void";
 
 export default defineConfig({
   staged: {
@@ -15,5 +14,4 @@ export default defineConfig({
       typeCheck: true,
     },
   },
-  plugins: [voidPlugin()],
 });


### PR DESCRIPTION
The site deploys to Void as a pre-built static site (`inference.appType: "static"` in `void.json`), which uploads the VitePress `build/` output directly and does not use `voidPlugin()`. The plugin only applies to Void apps (`routes/`, `pages/`, bindings, crons, queues) or meta-frameworks — none of which this site uses. `vitepress build` also reads `.vitepress/config/`, not the root `vite.config.ts`, so the plugin was never applied during the deploy build anyway.

`void` stays as a devDependency since the `void` CLI is what `vp run void deploy` invokes.

Verified locally:
- `vp check` — format, lint, type check all pass
- `vp run knip` — clean (exit 0); `void` still recognized via the `void` script/bin

🤖 Generated with [Claude Code](https://claude.com/claude-code)