### PR TITLE
docs: Add `sarif` and `agent` formats to docs page

### DIFF
--- a/src/docs/guide/usage/linter/ci.md
+++ b/src/docs/guide/usage/linter/ci.md
@@ -41,10 +41,13 @@ jobs:
   oxlint:
     runs-on: ubuntu-latest
     steps:
+      # NOTE: For security, it is strongly recommended to pin all
+      # actions to a specific SHA hash instead of using a version
+      # tag like this.
       - uses: actions/checkout@v6
-
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@v4
-
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
@@ -55,15 +58,7 @@ jobs:
       - run: pnpm run lint
 ```
 
-You can, alternatively, output using the github format option, for [better warning/error annotations](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message):
-
-```json [package.json]
-{
-  "scripts": {
-    "lint:github": "oxlint --format=github"
-  }
-}
-```
+By default, Oxlint will enable [better warning/error annotations](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message) when it detects that it is running in a GitHub Actions environment. You can override this behavior by providing the `--format` flag with a different formatter option.
 
 ### GitLab CI
 

--- a/src/docs/guide/usage/linter/output-formats.md
+++ b/src/docs/guide/usage/linter/output-formats.md
@@ -29,6 +29,16 @@ Found 0 warnings and 1 error.
 Finished in 6ms on 1 file with 2 rules using 1 threads.
 ```
 
+### `--format=agent`
+
+Outputs a brief format intended for consumption by AI agents and similar tooling.
+
+```
+test.js:5:1: error eslint(no-debugger): `debugger` statement is not allowed help: Remove the debugger statement
+test.js:1:10: warning eslint(no-unused-vars): Function 'foo' is declared but never used. help: Consider removing this declaration.
+test.js:1:17: warning eslint(no-unused-vars): Parameter 'b' is declared but never used. Unused parameters should start with a '_'. help: Consider removing this parameter.
+```
+
 ### `--format=checkstyle`
 
 Outputs Checkstyle XML format, which can be ingested by some CI tools.
@@ -49,6 +59,8 @@ This format is intended for use with GitHub Actions and GitHub's [annotations fe
 ```
 ::error file=test.js,line=5,endLine=5,col=1,endColumn=10,title=eslint(no-debugger)::`debugger` statement is not allowed
 ```
+
+It will be enabled by default when Oxlint detects that it is running in a GitHub Actions environment, you can override this behavior by providing a different `--format` option in your CI config.
 
 ### `--format=gitlab`
 
@@ -120,6 +132,75 @@ Outputs JUnit XML format, useful for CI systems that support JUnit reports, such
     </testcase>
   </testsuite>
 </testsuites>
+```
+
+### `--format=sarif`
+
+Outputs [SARIF](https://sarifweb.azurewebsites.net/) v2.1.0 format, which is a standardized format that can be ingested by various code scanning tools, including [GitHub Code Scanning](https://docs.github.com/en/code-security/concepts/code-scanning/sarif-files), [GitLab](https://docs.gitlab.com/user/application_security/detect/sarif/), and [SonarQube](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/importing-external-issues/importing-issues-from-sarif-reports).
+
+```json
+{
+  "version": "2.1.0",
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "oxlint",
+          "version": "1.66.0",
+          "semanticVersion": "1.66.0",
+          "informationUri": "https://oxc.rs/docs/guide/usage/linter.html",
+          "rules": [
+            {
+              "id": "eslint(no-debugger)",
+              "name": "no-debugger",
+              "helpUri": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html",
+              "properties": {
+                "category": "correctness",
+                "plugin": "eslint",
+                "fix": "fixable_suggestion"
+              }
+            }
+          ]
+        }
+      },
+      "artifacts": [
+        {
+          "location": {
+            "uri": "test.js"
+          }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "eslint(no-debugger)",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "`debugger` statement is not allowed"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "test.js",
+                  "index": 0
+                },
+                "region": {
+                  "startLine": 5,
+                  "startColumn": 1,
+                  "endLine": 5,
+                  "endColumn": 10
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "columnKind": "unicodeCodePoints"
+    }
+  ]
+}
 ```
 
 ### `--format=stylish`


### PR DESCRIPTION
And also some minor improvements to the CI docs page since it hasn't been updated to reflect some recent changes and was suggesting things which are not security-best-practice for GitHub Actions.

Resolves #1087