### PR TITLE
docs(transformer): document evaluation order and add React Compiler page

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -219,6 +219,10 @@ export const enConfig = defineLocaleConfig("root", {
               link: "/docs/guide/usage/transformer/jsx",
             },
             {
+              text: "React Compiler",
+              link: "/docs/guide/usage/transformer/react-compiler",
+            },
+            {
               text: "Plugins",
               link: "/docs/guide/usage/transformer/plugins",
             },

--- a/src/docs/guide/usage/transformer.md
+++ b/src/docs/guide/usage/transformer.md
@@ -4,12 +4,19 @@ A high-performance transformer that rewrites unsupported syntax into forms suppo
 
 ## Features
 
-- [Lowering ESNext to ES2015.](./transformer/lowering)
-- [Transforming TypeScript to JavaScript.](./transformer/typescript)
-- [Transforming JSX to JavaScript, with built-in React Refresh.](./transformer/jsx)
-- [Built-in support for popular plugins like styled-components.](./transformer/plugins)
-- [Replacing global variables.](./transformer/global-variable-replacement)
-- [TypeScript Isolated Declarations Emit without using the TypeScript compiler.](./transformer/isolated-declarations)
+The features below run in a fixed order, regardless of the order of the options:
+
+1. **[React Compiler](./transformer/react-compiler)** — runs first, on the original source.
+2. **[TypeScript](./transformer/typescript)** — type stripping.
+3. **[Decorators](./transformer/typescript#decorators)**.
+4. **[Plugins](./transformer/plugins)** — e.g. styled-components.
+5. **[React Refresh](./transformer/jsx#react-refresh)** — component instrumentation, runs just before the JSX transform.
+6. **[JSX](./transformer/jsx)** — JSX to JavaScript.
+7. **[Lowering](./transformer/lowering)** — ES2026 down to ES2015.
+8. **[Inject](./transformer/global-variable-replacement#inject)** — global variable injection.
+9. **[Define](./transformer/global-variable-replacement#define)** — global variable replacement.
+
+Oxc also supports [TypeScript Isolated Declarations emit](./transformer/isolated-declarations) without using the TypeScript compiler.
 
 ## General Options
 

--- a/src/docs/guide/usage/transformer/global-variable-replacement.md
+++ b/src/docs/guide/usage/transformer/global-variable-replacement.md
@@ -2,6 +2,10 @@
 
 Oxc transformer supports replacing global variables.
 
+::: tip Evaluation order
+`inject` runs before `define`, and both run after all other transforms. See the [transformer overview](../transformer#features) for the full order.
+:::
+
 ## Define
 
 "Define" feature provides a way to replace global variables with constant expressions. This feature is similar to [Terser](https://terser.org/)'s `global_defs` option and [esbuild's `define` option](https://esbuild.github.io/api/#define).

--- a/src/docs/guide/usage/transformer/react-compiler.md
+++ b/src/docs/guide/usage/transformer/react-compiler.md
@@ -1,0 +1,42 @@
+# React Compiler
+
+Oxc has experimental support for the [React Compiler](https://react.dev/learn/react-compiler), which automatically memoizes React components and hooks.
+
+::: warning
+This feature is experimental and under active development. Options and behaviour may change.
+:::
+
+Under the hood, Oxc integrates the [Rust port of the React Compiler](https://github.com/facebook/react/pull/36173) rather than the Babel-based `babel-plugin-react-compiler`. Because that port is an unmerged React PR and unpublished, Oxc vendors it as releasable crates at [oxc-project/forked-react-compiler](https://github.com/oxc-project/forked-react-compiler).
+
+## General Usage
+
+```js
+import { transform } from "oxc-transform";
+
+// Enable with default options.
+const result = await transform("App.jsx", sourceCode, {
+  reactCompiler: true,
+});
+
+// Or enable with options.
+const result = await transform("App.jsx", sourceCode, {
+  reactCompiler: {
+    // React runtime version target. `'17'` and `'18'` require the
+    // `react-compiler-runtime` package; `'19'` ships the runtime in `react`.
+    target: "19", // '17' | '18' | '19'
+  },
+});
+```
+
+Pass `false` or omit the option to disable the React Compiler.
+
+## When the React Compiler won't work
+
+The React Compiler [requires the original source](https://react.dev/learn/react-compiler/installation): it must see JSX before any other transform. Plugins that rewrite JSX first break this. Examples:
+
+- [`@emotion/babel-plugin`](https://emotion.sh/docs/@emotion/babel-plugin) and other `css` prop / JSX pragma transforms.
+- [`@babel/plugin-transform-react-constant-elements`](https://babeljs.io/docs/babel-plugin-transform-react-constant-elements) and `-inline-elements`, which hoist or inline JSX.
+
+This is why Oxc runs the React Compiler before its own JSX transform.
+
+Code that breaks the [Rules of React](https://react.dev/reference/rules) is also skipped rather than optimized — for example interior mutability, or libraries built on observable mutation such as MobX's `observer()`.


### PR DESCRIPTION
## What

- The transformer overview's Features list now shows the features in their fixed order of evaluation: React Compiler, TypeScript, Decorators, Plugins, React Refresh, JSX, Lowering, Inject, Define. Each links to its sub-page.
- New React Compiler page: usage, the upstream Rust port (https://github.com/facebook/react/pull/36173) and the oxc-project/forked-react-compiler vendored crates, and a section on when the compiler won't work (JSX-rewriting plugins, Rules of React violations).
- Global Variable Replacement notes that inject runs before define, both after the other transforms.
- Sidebar gains a React Compiler entry below JSX.