### PR TITLE
docs(transformer): react compiler to rust to merged

### DIFF
--- a/src/docs/guide/usage/transformer/react-compiler.md
+++ b/src/docs/guide/usage/transformer/react-compiler.md
@@ -6,7 +6,7 @@ Oxc has experimental support for the [React Compiler](https://react.dev/learn/re
 This feature is experimental and under active development. Options and behaviour may change.
 :::
 
-Under the hood, Oxc integrates the [Rust port of the React Compiler](https://github.com/facebook/react/pull/36173) rather than the Babel-based `babel-plugin-react-compiler`. Because that port is an unmerged React PR and unpublished, Oxc vendors it as releasable crates at [oxc-project/forked-react-compiler](https://github.com/oxc-project/forked-react-compiler).
+Under the hood, Oxc integrates the [Rust port of the React Compiler](https://github.com/facebook/react/pull/36173) rather than the Babel-based `babel-plugin-react-compiler`. Because that port is an merged React PR, but unpublished, Oxc vendors it as releasable crates at [oxc-project/forked-react-compiler](https://github.com/oxc-project/forked-react-compiler).
 
 ## General Usage
 


### PR DESCRIPTION
But I don't see it is used in the current React docs

https://github.com/react/react/pull/36173

<img width="952" height="646" alt="image" src="https://github.com/user-attachments/assets/1fabbe0a-46a7-4ff2-9d91-f6d2fb31458f" />

<img width="1540" height="784" alt="image" src="https://github.com/user-attachments/assets/92d575b6-d659-466c-afbf-028f4598c076" />
