### PR TITLE
ci: deploy website to Cloudflare

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,21 @@ jobs:
         env:
           VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
           VOID_PROJECT: oxc
+
+  deploy-cloudflare:
+    name: Deploy to Cloudflare
+    needs: [lint]
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-latest
+    environment: cloudflare
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - uses: voidzero-dev/setup-vp@2dec1e33f4ab2c6d5bce1b0c4607961bb1a3f7a1 # v1.12.0
+        with:
+          cache: ${{ github.ref_name == 'main' }}
+      - run: vp run build
+      - uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "oxc-website",
+  "compatibility_date": "2026-02-24",
+  "assets": {
+    // VitePress static output (outDir in .vitepress/config). Build with `vp run build`.
+    "directory": "./build",
+    // Serve build/404.html for unmatched routes.
+    "not_found_handling": "404-page",
+  },
+}


### PR DESCRIPTION
## Summary

Adds a `deploy-cloudflare` job to CI that deploys the website to Cloudflare on every push to `main`, mirroring the existing `deploy-void` job.

- Builds the VitePress site with `vp run build` (output dir `./build`).
- Deploys via the official `cloudflare/wrangler-action`, pinned to `v4.0.0` (which installs Wrangler v4 by default).
- Tracks `wrangler.jsonc` — the Workers static-assets config that serves `./build`, with `404-page` fallback for unmatched routes.

## Required setup

Before this can deploy, create a `cloudflare` GitHub Environment (Settings → Environments) with two secrets:

- `CLOUDFLARE_API_TOKEN` — a Cloudflare API token with Workers deploy permission.
- `CLOUDFLARE_ACCOUNT_ID` — the target Cloudflare account ID.

## Notes

- Runs on `main` only (`if: github.ref_name == 'main'`), after `lint`, in parallel with `deploy-void`.
- Wrangler is provided by the action, so no `package.json` / lockfile changes are needed.