### PR TITLE
docs(website): update checkout action examples

### DIFF
--- a/src/docs/guide/usage/formatter/ci.md
+++ b/src/docs/guide/usage/formatter/ci.md
@@ -39,7 +39,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v4
 
@@ -76,7 +76,7 @@ jobs:
   autofix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: pnpm/action-setup@v4
 

--- a/src/docs/guide/usage/linter/ci.md
+++ b/src/docs/guide/usage/linter/ci.md
@@ -44,7 +44,7 @@ jobs:
       # NOTE: For security, it is strongly recommended to pin all
       # actions to a specific SHA hash instead of using a version
       # tag like this.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
Updates the checkout action version in the CI documentation examples.
