### PR TITLE
docs: add Language support reference page for Oxfmt

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -187,6 +187,10 @@ export const enConfig = defineLocaleConfig("root", {
                   link: "/docs/guide/usage/formatter/config-file-reference",
                 },
                 {
+                  text: "Language support",
+                  link: "/docs/guide/usage/formatter/language-support",
+                },
+                {
                   text: "Unsupported features",
                   link: "/docs/guide/usage/formatter/unsupported-features",
                 },

--- a/src/docs/guide/usage/formatter.md
+++ b/src/docs/guide/usage/formatter.md
@@ -24,7 +24,7 @@ Oxfmt is the recommended choice when you want a dedicated formatter with a Prett
 
 Support includes JavaScript, JSX, TypeScript, TSX, JSON, JSONC, JSON5, YAML, TOML, HTML, Angular, Vue, Svelte, CSS, SCSS, Less, Markdown, MDX, GraphQL, Ember, Handlebars, and more.
 
-See the [compatibility matrix](/compatibility) for detailed framework and file type support.
+See [Language support](./formatter/language-support) for the full list and which languages are formatted natively in Rust, and the [compatibility matrix](/compatibility) for detailed framework and file type support.
 
 ## Built for scale
 
@@ -97,4 +97,5 @@ pnpm run fmt:check
 
 - [CLI reference](./formatter/cli)
 - [Config file reference](./formatter/config-file-reference)
+- [Language support](./formatter/language-support)
 - [Unsupported features](./formatter/unsupported-features)

--- a/src/docs/guide/usage/formatter/language-support.md
+++ b/src/docs/guide/usage/formatter/language-support.md
@@ -1,0 +1,57 @@
+---
+title: "Language support | Oxfmt"
+---
+
+# Language support
+
+Oxfmt formats a wide range of file types. Most are handled by Oxfmt's own **native** engine, written in Rust. The rest are delegated to a **bundled Prettier** for languages Oxfmt has not yet reimplemented natively. We are actively porting every language to Rust for maximum performance, so the Prettier-backed list keeps shrinking as native support lands.
+
+:::info
+Native formats run entirely in Rust with no Node.js round-trip, so they are the fastest. Prettier-backed formats ship inside the `oxfmt` package and need no extra setup — except `.svelte`, which additionally requires the `svelte` package to be installed and the [`svelte`](./config-file-reference) option to be enabled.
+:::
+
+## Native
+
+Formatted directly by Oxfmt, with no Prettier dependency:
+
+| Language             | Extensions                                    |
+| -------------------- | --------------------------------------------- |
+| JavaScript / JSX     | `.js`, `.jsx`, `.mjs`, `.cjs`, and more       |
+| TypeScript / TSX     | `.ts`, `.tsx`, `.mts`, `.cts`, `.d.ts`        |
+| JSON / JSONC / JSON5 | `.json`, `.jsonc`, `.json5`                   |
+| CSS / SCSS / Less    | `.css`, `.scss`, `.less`, `.pcss`, `.postcss` |
+| GraphQL              | `.graphql`, `.gql`, `.graphqls`               |
+| TOML                 | `.toml`                                       |
+
+Detection also covers many well-known config files by name — for example `.babelrc` and `.swcrc` are treated as JSON. `package.json` is additionally sorted before formatting (see [Sorting](./sorting)).
+
+## Prettier-backed
+
+Delegated to the bundled Prettier. No separate `prettier` install is required.
+
+:::tip
+These are being actively ported to Rust. As each native formatter lands, its language moves to the [Native](#native) list above for maximum performance — no change needed on your side.
+:::
+
+| Language   | Extensions                |
+| ---------- | ------------------------- |
+| HTML       | `.html`, `.htm`, `.xhtml` |
+| Angular    | `*.component.html`        |
+| Vue        | `.vue`                    |
+| Svelte     | `.svelte`                 |
+| Markdown   | `.md`, `.markdown`        |
+| MDX        | `.mdx`                    |
+| YAML       | `.yml`, `.yaml`           |
+| Handlebars | `.hbs`, `.handlebars`     |
+| MJML       | `.mjml`                   |
+
+Some config files are also matched by name — for example `.prettierrc` and `.clang-format` are treated as YAML. When Prettier formats a file that embeds JavaScript or TypeScript (such as a Vue or Svelte `<script>` block), that embedded code is formatted by Oxfmt's native engine rather than Prettier.
+
+## Embedded languages
+
+Oxfmt also formats code embedded inside JS/TS template literals. CSS and GraphQL are formatted natively; HTML and Markdown go through Prettier. See [Embedded Formatting](./embedded-formatting) for details and examples.
+
+## See also
+
+- [Compatibility matrix](/compatibility) — framework- and file-type-level support at a glance
+- [Unsupported features](./unsupported-features)

--- a/src/docs/guide/usage/formatter/language-support.md
+++ b/src/docs/guide/usage/formatter/language-support.md
@@ -7,7 +7,7 @@ title: "Language support | Oxfmt"
 Oxfmt formats a wide range of file types. Most are handled by Oxfmt's own **native** engine, written in Rust. The rest are delegated to a **bundled Prettier** for languages Oxfmt has not yet reimplemented natively. We are actively porting every language to Rust for maximum performance, so the Prettier-backed list keeps shrinking as native support lands.
 
 :::info
-Native formats run entirely in Rust with no Node.js round-trip, so they are the fastest. Prettier-backed formats ship inside the `oxfmt` package and need no extra setup — except `.svelte`, which additionally requires the `svelte` package to be installed and the [`svelte`](./config-file-reference) option to be enabled.
+Native formats run entirely in Rust with no Node.js round-trip, so they are the fastest. Prettier-backed formats ship inside the `oxfmt` package and need no extra setup. Except `.svelte`, which additionally requires the `svelte` package to be installed and the [`svelte`](./config-file-reference) option to be enabled.
 :::
 
 ## Native
@@ -23,14 +23,14 @@ Formatted directly by Oxfmt, with no Prettier dependency:
 | GraphQL              | `.graphql`, `.gql`, `.graphqls`               |
 | TOML                 | `.toml`                                       |
 
-Detection also covers many well-known config files by name — for example `.babelrc` and `.swcrc` are treated as JSON. `package.json` is additionally sorted before formatting (see [Sorting](./sorting)).
+Detection also covers many well-known config files by name. For example `.babelrc` and `.swcrc` are treated as JSON.
 
 ## Prettier-backed
 
 Delegated to the bundled Prettier. No separate `prettier` install is required.
 
 :::tip
-These are being actively ported to Rust. As each native formatter lands, its language moves to the [Native](#native) list above for maximum performance — no change needed on your side.
+These are being actively ported to Rust. As each native formatter lands, its language moves to the [Native](#native) list above for maximum performance. No change needed on your side.
 :::
 
 | Language   | Extensions                |
@@ -45,11 +45,11 @@ These are being actively ported to Rust. As each native formatter lands, its lan
 | Handlebars | `.hbs`, `.handlebars`     |
 | MJML       | `.mjml`                   |
 
-Some config files are also matched by name — for example `.prettierrc` and `.clang-format` are treated as YAML. When Prettier formats a file that embeds JavaScript or TypeScript (such as a Vue or Svelte `<script>` block), that embedded code is formatted by Oxfmt's native engine rather than Prettier.
-
 ## Embedded languages
 
 Oxfmt also formats code embedded inside JS/TS template literals. CSS and GraphQL are formatted natively; HTML and Markdown go through Prettier. See [Embedded Formatting](./embedded-formatting) for details and examples.
+
+For Vue and Svelte files, embedded JavaScript and TypeScript (such as `<script>` blocks) is formatted by Oxfmt's native engine rather than Prettier. Embedded JS/TS in the other Prettier-backed formats (such as `<script>` tags in HTML) is still formatted by Prettier.
 
 ## See also
 


### PR DESCRIPTION
I was looking for what's native and what's not.