### PR TITLE
ci: deploy to Void via GitHub OIDC instead of stored token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,19 +31,3 @@ jobs:
       - uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
         with:
           files: .
-
-  deploy-void:
-    name: Deploy to Void
-    needs: [lint]
-    if: github.ref_name == 'main'
-    runs-on: ubuntu-latest
-    environment: void
-    steps:
-      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
-      - uses: voidzero-dev/setup-vp@35171c92dd08b67d5a9d3f2a4327800e58396f2a # v1.13.0
-        with:
-          cache: ${{ github.ref_name == 'main' }}
-      - run: vp run void deploy
-        env:
-          VOID_TOKEN: ${{ secrets.VOID_TOKEN }}
-          VOID_PROJECT: oxc

--- a/.github/workflows/void-deploy.yml
+++ b/.github/workflows/void-deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to Void
+
+permissions:
+  id-token: write # Required for the OIDC exchange performed by `void deploy`.
+  contents: read
+
+on:
+  push:
+    branches:
+      - main
+
+# Latest push wins: a newer commit cancels an in-flight deploy.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to Void
+    runs-on: ubuntu-latest
+    steps:
+      - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+      - uses: voidzero-dev/setup-vp@35171c92dd08b67d5a9d3f2a4327800e58396f2a # v1.13.0
+        with:
+          cache: true
+      - run: vp run void deploy
+        env:
+          VOID_PROJECT: oxc


### PR DESCRIPTION
Switches the Void deploy from the stored `VOID_TOKEN` secret to GitHub OIDC.

- Adds a dedicated `.github/workflows/void-deploy.yml` (push to `main`, `permissions: id-token: write`, latest-push-wins concurrency). `void deploy` detects GitHub Actions and exchanges a short-lived OIDC token for a project-scoped deploy token, so no secret is stored.
- Removes the `deploy-void` job from `ci.yml`.

The dedicated file is required: the project's Void GitHub connection (`void github status oxc`) pins OIDC trust to `.github/workflows/void-deploy.yml` with executor `github_actions` on branch `main` — only that workflow can mint a deploy token.

Follow-up after the first successful deploy: the `VOID_TOKEN` secret and the `void` environment in repo settings are unused and can be deleted. Note the deploy is no longer gated on the lint job; lint still gates PRs into `main`.