### PR TITLE
docs: move payout note to why sponsor and mention avatar placement

### DIFF
--- a/src/sponsor.md
+++ b/src/sponsor.md
@@ -6,13 +6,17 @@ editLink: false
 
 ## 🤝 How to Sponsor
 
-You may sponsor through [OpenCollective](https://opencollective.com/oxc). Sponsorships received there are paid out to core team members who are not part of [VoidZero](https://voidzero.dev).
+You may sponsor through [OpenCollective](https://opencollective.com/oxc).
 
 Our [GitHub Sponsors](https://github.com/sponsors/oxc-project) page hit a bug during setup and is still pending, so it is not available yet.
 
 ## 💚 Why sponsor?
 
 Sponsorship helps us keep improving the JavaScript and Rust ecosystems while preventing burnout from maintaining fast and evolving tools in our personal time.
+
+Sponsorships received on OpenCollective are paid out to core team members who are not part of [VoidZero](https://voidzero.dev).
+
+As a sponsor, your avatar is displayed across all [oxc-project repositories](https://github.com/oxc-project) and on the [landing page](/) of this website.
 
 If our work has improved your development experience, your CI pipelines, your build times, or your learning in any way, please consider sponsoring. It helps more than you might think, and it truly keeps the motivation alive.
 


### PR DESCRIPTION
Moves the OpenCollective payout note from "How to Sponsor" into "Why sponsor?", reworded to name OpenCollective explicitly since it no longer sits next to the link.

Also adds a line noting that a sponsor's avatar is displayed across all oxc-project repositories and on the landing page of this website.