### PR TITLE
docs: improve sponsor page readability

### DIFF
--- a/src/sponsor.md
+++ b/src/sponsor.md
@@ -6,19 +6,19 @@ editLink: false
 
 ## 🤝 How to Sponsor
 
-You may sponsor through [OpenCollective](https://opencollective.com/oxc).
+You can sponsor us on [OpenCollective](https://opencollective.com/oxc).
 
-Our [GitHub Sponsors](https://github.com/sponsors/oxc-project) page hit a bug during setup and is still pending, so it is not available yet.
+Our [GitHub Sponsors](https://github.com/sponsors/oxc-project) page hit a bug during setup and is still pending, so OpenCollective is the only option for now.
 
 ## 💚 Why sponsor?
 
-Sponsorship helps us keep improving the JavaScript and Rust ecosystems while preventing burnout from maintaining fast and evolving tools in our personal time.
+Sponsorship lets us keep improving the JavaScript and Rust ecosystems without burning out.
 
-Sponsorships received on OpenCollective are paid out to core team members who are not part of [VoidZero](https://voidzero.dev).
+Everything we receive on OpenCollective is paid out to core team members who are not part of [VoidZero](https://voidzero.dev).
 
 As a sponsor, your avatar is displayed across all [oxc-project repositories](https://github.com/oxc-project) and on the [landing page](/) of this website.
 
-If our work has improved your development experience, your CI pipelines, your build times, or your learning in any way, please consider sponsoring. It helps more than you might think, and it truly keeps the motivation alive.
+If our work has improved your development experience, your CI pipelines, your build times, or your learning, please consider sponsoring. It helps more than you might think, and it keeps the motivation alive.
 
 ## Current Sponsors
 


### PR DESCRIPTION
A prose pass over the sponsor page, rebased on top of #1213.

**How to Sponsor**
- "You may sponsor through" → "You can sponsor us on".
- The GitHub Sponsors line ended with "is still pending, so it is not available yet" — "still pending" and "not available yet" say the same thing twice. The tail now reads "so OpenCollective is the only option for now", which tells the reader what to do instead.

**Why sponsor?**
- The opening sentence packed three ideas into one clause and read as though the tools themselves were "fast and evolving". It is now just "Sponsorship lets us keep improving the JavaScript and Rust ecosystems without burning out."
- "Sponsorships received on OpenCollective are paid out to" → "Everything we receive on OpenCollective is paid out to".
- Cut the filler "in any way" and "truly".

One content change beyond wording: the page no longer mentions that the work happens in our personal time. That idea was in the original line and is dropped rather than reworded.