### PR TITLE
docs: explain how plugins merges under extends

### DIFF
--- a/src/docs/guide/usage/linter/nested-config.md
+++ b/src/docs/guide/usage/linter/nested-config.md
@@ -178,3 +178,20 @@ Only some properties can be extended. The supported properties are:
 - `rules`
 - `plugins`
 - `overrides`
+
+### How `plugins` merges
+
+Each config in an `extends` chain contributes its `plugins` list, and the result is the union of all contributions. A config that does not declare `plugins` contributes the default plugins instead.
+
+This means extending a config with a narrower `plugins` list than the defaults is not enough on its own: if the extending config omits `plugins`, the defaults are added back on top of the extended list.
+
+To inherit exactly the plugins of the extended config, declare an empty array:
+
+```json [.oxlintrc.json]
+{
+  "extends": ["./base.json"],
+  "plugins": []
+}
+```
+
+The empty array is an empty contribution, so the result is exactly the plugins declared by `base.json`. Declaring a non-empty list works the same way: the union of that list and the extended config's list, without the defaults.

--- a/src/docs/guide/usage/linter/nested-config.md
+++ b/src/docs/guide/usage/linter/nested-config.md
@@ -187,6 +187,8 @@ This means extending a config with a narrower `plugins` list than the defaults i
 
 To inherit exactly the plugins of the extended config, declare an empty array:
 
+::: code-group
+
 ```json [.oxlintrc.json]
 {
   "extends": ["./base.json"],
@@ -194,4 +196,18 @@ To inherit exactly the plugins of the extended config, declare an empty array:
 }
 ```
 
-The empty array is an empty contribution, so the result is exactly the plugins declared by `base.json`. Declaring a non-empty list works the same way: the union of that list and the extended config's list, without the defaults.
+```ts [oxlint.config.ts]
+import baseConfig from "./base.config.ts";
+import { defineConfig } from "oxlint";
+
+export default defineConfig({
+  extends: [baseConfig],
+  plugins: [],
+});
+```
+
+:::
+
+The empty array is an empty contribution, so the result is exactly the plugins declared by `base.json`. Declaring a non-empty list works the same way: the union of that list and the extended lists, with the defaults only appearing if some config in the chain omits `plugins`.
+
+This is the same mechanism as [disabling the default plugins](./plugins) with `"plugins": []` in a standalone config: an explicit array replaces the config's default contribution.


### PR DESCRIPTION
Documents how `plugins` merges under `extends` on the nested-config page: each config contributes its `plugins` list (or the default plugins if it declares none), the contributions union, and `"plugins": []` gives exact inheritance.

The behavior is intended: implemented in #22896/#22903 (oxc-project/oxc), asserted by `test_extends_plugins` in `crates/oxc_linter/src/config/config_builder.rs`, and the empty-array idiom is the escape hatch described in #22896 itself, but none of it was documented. Surfaced in oxc-project/oxc#24836 while centralizing oxlint config for a 5-app pnpm monorepo. Verified by hand on oxlint 1.75.0; applies identically to the JSON and TS config formats (both fold through `Oxlintrc::merge`).

I used Claude Code to help draft this; I reviewed the text and verified the described behavior myself.
