### PR TITLE
docs: document TypeScript Runner

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -22,7 +22,10 @@ export const enConfig = defineLocaleConfig("root", {
           { text: "Transformer", link: "/docs/guide/usage/transformer" },
           { text: "Minifier", link: "/docs/guide/usage/minifier" },
           { text: "Resolver", link: "/docs/guide/usage/resolver" },
-          { text: "TypeScript Runner", link: "/docs/guide/usage/oxc-node" },
+          {
+            text: "TypeScript Runner (Experimental)",
+            link: "/docs/guide/usage/oxc-node",
+          },
         ],
       },
       { text: "Contribute", link: "/docs/contribute/introduction" },
@@ -279,7 +282,7 @@ export const enConfig = defineLocaleConfig("root", {
           items: [{ text: "Overview", link: "/docs/guide/usage/resolver" }],
         },
         {
-          text: "TypeScript Runner",
+          text: "TypeScript Runner (Experimental)",
           collapsed: true,
           link: "/docs/guide/usage/oxc-node",
           items: [{ text: "Overview", link: "/docs/guide/usage/oxc-node" }],

--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -22,6 +22,7 @@ export const enConfig = defineLocaleConfig("root", {
           { text: "Transformer", link: "/docs/guide/usage/transformer" },
           { text: "Minifier", link: "/docs/guide/usage/minifier" },
           { text: "Resolver", link: "/docs/guide/usage/resolver" },
+          { text: "Oxc Node", link: "/docs/guide/usage/oxc-node" },
         ],
       },
       { text: "Contribute", link: "/docs/contribute/introduction" },
@@ -276,6 +277,12 @@ export const enConfig = defineLocaleConfig("root", {
           collapsed: true,
           link: "/docs/guide/usage/resolver",
           items: [{ text: "Overview", link: "/docs/guide/usage/resolver" }],
+        },
+        {
+          text: "Oxc Node",
+          collapsed: true,
+          link: "/docs/guide/usage/oxc-node",
+          items: [{ text: "Overview", link: "/docs/guide/usage/oxc-node" }],
         },
         {
           text: "Resources",

--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -22,7 +22,7 @@ export const enConfig = defineLocaleConfig("root", {
           { text: "Transformer", link: "/docs/guide/usage/transformer" },
           { text: "Minifier", link: "/docs/guide/usage/minifier" },
           { text: "Resolver", link: "/docs/guide/usage/resolver" },
-          { text: "Oxc Node", link: "/docs/guide/usage/oxc-node" },
+          { text: "TypeScript Runner", link: "/docs/guide/usage/oxc-node" },
         ],
       },
       { text: "Contribute", link: "/docs/contribute/introduction" },
@@ -279,7 +279,7 @@ export const enConfig = defineLocaleConfig("root", {
           items: [{ text: "Overview", link: "/docs/guide/usage/resolver" }],
         },
         {
-          text: "Oxc Node",
+          text: "TypeScript Runner",
           collapsed: true,
           link: "/docs/guide/usage/oxc-node",
           items: [{ text: "Overview", link: "/docs/guide/usage/oxc-node" }],

--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -22,10 +22,7 @@ export const enConfig = defineLocaleConfig("root", {
           { text: "Transformer", link: "/docs/guide/usage/transformer" },
           { text: "Minifier", link: "/docs/guide/usage/minifier" },
           { text: "Resolver", link: "/docs/guide/usage/resolver" },
-          {
-            text: "TypeScript Runner (Experimental)",
-            link: "/docs/guide/usage/oxc-node",
-          },
+          { text: "TypeScript Runner", link: "/docs/guide/usage/oxc-node" },
         ],
       },
       { text: "Contribute", link: "/docs/contribute/introduction" },
@@ -282,7 +279,7 @@ export const enConfig = defineLocaleConfig("root", {
           items: [{ text: "Overview", link: "/docs/guide/usage/resolver" }],
         },
         {
-          text: "TypeScript Runner (Experimental)",
+          text: "TypeScript Runner",
           collapsed: true,
           link: "/docs/guide/usage/oxc-node",
           items: [{ text: "Overview", link: "/docs/guide/usage/oxc-node" }],

--- a/.vitepress/config/shared.ts
+++ b/.vitepress/config/shared.ts
@@ -176,7 +176,10 @@ export const sharedConfig = {
             { text: "Transformer", link: "/docs/guide/usage/transformer" },
             { text: "Minifier", link: "/docs/guide/usage/minifier" },
             { text: "Resolver", link: "/docs/guide/usage/resolver" },
-            { text: "TypeScript Runner", link: "/docs/guide/usage/oxc-node" },
+            {
+              text: "TypeScript Runner (Experimental)",
+              link: "/docs/guide/usage/oxc-node",
+            },
           ],
         },
         {

--- a/.vitepress/config/shared.ts
+++ b/.vitepress/config/shared.ts
@@ -176,6 +176,7 @@ export const sharedConfig = {
             { text: "Transformer", link: "/docs/guide/usage/transformer" },
             { text: "Minifier", link: "/docs/guide/usage/minifier" },
             { text: "Resolver", link: "/docs/guide/usage/resolver" },
+            { text: "Oxc Node", link: "/docs/guide/usage/oxc-node" },
           ],
         },
         {

--- a/.vitepress/config/shared.ts
+++ b/.vitepress/config/shared.ts
@@ -176,7 +176,7 @@ export const sharedConfig = {
             { text: "Transformer", link: "/docs/guide/usage/transformer" },
             { text: "Minifier", link: "/docs/guide/usage/minifier" },
             { text: "Resolver", link: "/docs/guide/usage/resolver" },
-            { text: "Oxc Node", link: "/docs/guide/usage/oxc-node" },
+            { text: "TypeScript Runner", link: "/docs/guide/usage/oxc-node" },
           ],
         },
         {

--- a/.vitepress/config/shared.ts
+++ b/.vitepress/config/shared.ts
@@ -176,10 +176,7 @@ export const sharedConfig = {
             { text: "Transformer", link: "/docs/guide/usage/transformer" },
             { text: "Minifier", link: "/docs/guide/usage/minifier" },
             { text: "Resolver", link: "/docs/guide/usage/resolver" },
-            {
-              text: "TypeScript Runner (Experimental)",
-              link: "/docs/guide/usage/oxc-node",
-            },
+            { text: "TypeScript Runner", link: "/docs/guide/usage/oxc-node" },
           ],
         },
         {

--- a/src/docs/guide/introduction.md
+++ b/src/docs/guide/introduction.md
@@ -17,7 +17,7 @@ title: Getting Started
 - Transform TypeScript, JSX, and modern JavaScript: [Transformer](/docs/guide/usage/transformer)
 - Minify JavaScript for production builds: [Minifier](/docs/guide/usage/minifier)
 - Resolve modules for JavaScript and TypeScript: [Resolver](/docs/guide/usage/resolver)
-- Run TypeScript and JSX directly in Node.js: [Oxc Node](/docs/guide/usage/oxc-node)
+- Run TypeScript and JSX directly in Node.js: [TypeScript Runner](/docs/guide/usage/oxc-node)
 
 ## Contribute or learn
 

--- a/src/docs/guide/introduction.md
+++ b/src/docs/guide/introduction.md
@@ -17,6 +17,7 @@ title: Getting Started
 - Transform TypeScript, JSX, and modern JavaScript: [Transformer](/docs/guide/usage/transformer)
 - Minify JavaScript for production builds: [Minifier](/docs/guide/usage/minifier)
 - Resolve modules for JavaScript and TypeScript: [Resolver](/docs/guide/usage/resolver)
+- Run TypeScript and JSX directly in Node.js: [Oxc Node](/docs/guide/usage/oxc-node)
 
 ## Contribute or learn
 

--- a/src/docs/guide/introduction.md
+++ b/src/docs/guide/introduction.md
@@ -17,7 +17,7 @@ title: Getting Started
 - Transform TypeScript, JSX, and modern JavaScript: [Transformer](/docs/guide/usage/transformer)
 - Minify JavaScript for production builds: [Minifier](/docs/guide/usage/minifier)
 - Resolve modules for JavaScript and TypeScript: [Resolver](/docs/guide/usage/resolver)
-- Run TypeScript and JSX directly in Node.js: [TypeScript Runner (Experimental)](/docs/guide/usage/oxc-node)
+- Run TypeScript and JSX directly in Node.js: [TypeScript Runner](/docs/guide/usage/oxc-node)
 
 ## Contribute or learn
 

--- a/src/docs/guide/introduction.md
+++ b/src/docs/guide/introduction.md
@@ -17,7 +17,7 @@ title: Getting Started
 - Transform TypeScript, JSX, and modern JavaScript: [Transformer](/docs/guide/usage/transformer)
 - Minify JavaScript for production builds: [Minifier](/docs/guide/usage/minifier)
 - Resolve modules for JavaScript and TypeScript: [Resolver](/docs/guide/usage/resolver)
-- Run TypeScript and JSX directly in Node.js: [TypeScript Runner](/docs/guide/usage/oxc-node)
+- Run TypeScript and JSX directly in Node.js: [TypeScript Runner (Experimental)](/docs/guide/usage/oxc-node)
 
 ## Contribute or learn
 

--- a/src/docs/guide/usage/oxc-node.md
+++ b/src/docs/guide/usage/oxc-node.md
@@ -1,14 +1,14 @@
 ---
-title: Oxc Node
+title: TypeScript Runner
 description: Run TypeScript and JSX directly in Node.js with Oxc.
 outline: deep
 ---
 
-# Oxc Node
+# TypeScript Runner
 
-[Oxc Node](https://github.com/oxc-project/oxc-node) is a fast Node.js development tool powered by the Oxc transformer and resolver. It runs TypeScript and JSX without a separate build step while preserving the standard Node.js command-line workflow.
+[`oxc-node`](https://github.com/oxc-project/oxc-node) is Oxc's TypeScript runner. It runs TypeScript and JSX without a separate build step while preserving the standard Node.js command-line workflow.
 
-Oxc Node provides:
+The runner provides:
 
 - The `oxnode` command for running scripts and starting a REPL.
 - A Node.js register hook for use with `node --import`.
@@ -42,7 +42,7 @@ $ bun add -D @oxc-node/cli
 :::
 
 ::: tip
-A project-local installation keeps the Oxc Node version consistent across your team. You can instead install `@oxc-node/cli` globally if you want to invoke `oxnode` outside a project or package script.
+A project-local installation keeps the runner version consistent across your team. You can instead install `@oxc-node/cli` globally if you want to invoke `oxnode` outside a project or package script.
 :::
 
 Run a TypeScript entry point:
@@ -143,16 +143,16 @@ Module format is inferred from the file extension, the nearest `package.json`, a
 
 ## TypeScript configuration
 
-Oxc Node reads `tsconfig.json` from the current working directory. Set `OXC_TSCONFIG_PATH` or `TS_NODE_PROJECT` to use a different file:
+The runner reads `tsconfig.json` from the current working directory. Set `OXC_TSCONFIG_PATH` or `TS_NODE_PROJECT` to use a different file:
 
 ```sh
 OXC_TSCONFIG_PATH=./config/tsconfig.dev.json oxnode ./src/index.ts
 ```
 
-The transformer uses relevant compiler options for module format, JSX, decorators, class fields, and rewriting relative import extensions. TypeScript types are stripped during transformation; Oxc Node does not type-check your program.
+The transformer uses relevant compiler options for module format, JSX, decorators, class fields, and rewriting relative import extensions. TypeScript types are stripped during transformation; the runner does not type-check your program.
 
 ## Links
 
-- [Oxc Node repository](https://github.com/oxc-project/oxc-node)
+- [`oxc-node` repository](https://github.com/oxc-project/oxc-node)
 - [`@oxc-node/cli`](https://npmx.dev/package/@oxc-node/cli)
 - [`@oxc-node/core`](https://npmx.dev/package/@oxc-node/core)

--- a/src/docs/guide/usage/oxc-node.md
+++ b/src/docs/guide/usage/oxc-node.md
@@ -109,32 +109,6 @@ Because this uses Node.js's register hook, it composes with other Node.js comman
 node --import @oxc-node/core/register --test ./test.ts
 ```
 
-## Programmatic transformation
-
-The core package exposes a synchronous `transform` function:
-
-```ts
-import { transform } from "@oxc-node/core";
-
-const output = transform("example.ts", "const answer: number = 42;");
-
-console.log(output.source());
-console.log(output.sourceMap());
-```
-
-Create an `OxcTransformer` when you want to reuse a working directory or transform asynchronously:
-
-```ts
-import { OxcTransformer } from "@oxc-node/core";
-
-const transformer = new OxcTransformer(process.cwd());
-const output = await transformer.transformAsync("example.ts", "const answer: number = 42;");
-
-console.log(output.source());
-```
-
-The filename determines how the source is parsed. `source()` returns the generated JavaScript, and `sourceMap()` returns a JSON source map or `null`.
-
 ## Supported files
 
 The register hook transforms the following extensions:

--- a/src/docs/guide/usage/oxc-node.md
+++ b/src/docs/guide/usage/oxc-node.md
@@ -1,16 +1,16 @@
 ---
-title: TypeScript Runner (Experimental)
+title: TypeScript Runner
 description: Run TypeScript and JSX directly in Node.js with Oxc.
 outline: deep
 ---
 
 # TypeScript Runner
 
-[`oxc-node`](https://github.com/oxc-project/oxc-node) is Oxc's TypeScript runner. It runs TypeScript and JSX without a separate build step while preserving the standard Node.js command-line workflow.
-
-::: warning Experimental
+::: info Experimental
 The TypeScript runner is experimental and under active development. APIs and behavior may change between releases.
 :::
+
+[`oxc-node`](https://github.com/oxc-project/oxc-node) is Oxc's TypeScript runner. It runs TypeScript and JSX without a separate build step while preserving the standard Node.js command-line workflow.
 
 The runner provides:
 

--- a/src/docs/guide/usage/oxc-node.md
+++ b/src/docs/guide/usage/oxc-node.md
@@ -1,5 +1,5 @@
 ---
-title: TypeScript Runner
+title: TypeScript Runner (Experimental)
 description: Run TypeScript and JSX directly in Node.js with Oxc.
 outline: deep
 ---
@@ -7,6 +7,10 @@ outline: deep
 # TypeScript Runner
 
 [`oxc-node`](https://github.com/oxc-project/oxc-node) is Oxc's TypeScript runner. It runs TypeScript and JSX without a separate build step while preserving the standard Node.js command-line workflow.
+
+::: warning Experimental
+The TypeScript runner is experimental and under active development. APIs and behavior may change between releases.
+:::
 
 The runner provides:
 

--- a/src/docs/guide/usage/oxc-node.md
+++ b/src/docs/guide/usage/oxc-node.md
@@ -1,0 +1,158 @@
+---
+title: Oxc Node
+description: Run TypeScript and JSX directly in Node.js with Oxc.
+outline: deep
+---
+
+# Oxc Node
+
+[Oxc Node](https://github.com/oxc-project/oxc-node) is a fast Node.js development tool powered by the Oxc transformer and resolver. It runs TypeScript and JSX without a separate build step while preserving the standard Node.js command-line workflow.
+
+Oxc Node provides:
+
+- The `oxnode` command for running scripts and starting a REPL.
+- A Node.js register hook for use with `node --import`.
+- Synchronous and asynchronous transformation APIs.
+- ESM and CommonJS support.
+- Source maps for stack traces.
+- `tsconfig.json` integration.
+
+## CLI
+
+Install [`@oxc-node/cli`](https://npmx.dev/package/@oxc-node/cli) as a development dependency:
+
+::: code-group
+
+```sh [npm]
+$ npm add -D @oxc-node/cli
+```
+
+```sh [pnpm]
+$ pnpm add -D @oxc-node/cli
+```
+
+```sh [yarn]
+$ yarn add -D @oxc-node/cli
+```
+
+```sh [bun]
+$ bun add -D @oxc-node/cli
+```
+
+:::
+
+::: tip
+A project-local installation keeps the Oxc Node version consistent across your team. You can instead install `@oxc-node/cli` globally if you want to invoke `oxnode` outside a project or package script.
+:::
+
+Run a TypeScript entry point:
+
+```sh
+oxnode ./src/index.ts
+```
+
+Arguments are passed through to Node.js, so Node.js features such as watch mode remain available:
+
+```sh
+oxnode --watch ./src/index.ts
+```
+
+Running `oxnode` without a script starts the Node.js REPL. Use `oxnode --node-help` to display Node.js command-line help.
+
+For a repeatable project command, add a script to `package.json`:
+
+```json [package.json]
+{
+  "scripts": {
+    "dev": "oxnode ./src/index.ts"
+  }
+}
+```
+
+## Node.js register hook
+
+Install [`@oxc-node/core`](https://npmx.dev/package/@oxc-node/core) when you want to keep using the `node` command directly:
+
+::: code-group
+
+```sh [npm]
+$ npm add -D @oxc-node/core
+```
+
+```sh [pnpm]
+$ pnpm add -D @oxc-node/core
+```
+
+```sh [yarn]
+$ yarn add -D @oxc-node/core
+```
+
+```sh [bun]
+$ bun add -D @oxc-node/core
+```
+
+:::
+
+Register Oxc before loading the entry point:
+
+```sh
+node --import @oxc-node/core/register ./src/index.ts
+```
+
+Because this uses Node.js's register hook, it composes with other Node.js commands and flags. For example, run TypeScript tests with the built-in test runner:
+
+```sh
+node --import @oxc-node/core/register --test ./test.ts
+```
+
+## Programmatic transformation
+
+The core package exposes a synchronous `transform` function:
+
+```ts
+import { transform } from "@oxc-node/core";
+
+const output = transform("example.ts", "const answer: number = 42;");
+
+console.log(output.source());
+console.log(output.sourceMap());
+```
+
+Create an `OxcTransformer` when you want to reuse a working directory or transform asynchronously:
+
+```ts
+import { OxcTransformer } from "@oxc-node/core";
+
+const transformer = new OxcTransformer(process.cwd());
+const output = await transformer.transformAsync("example.ts", "const answer: number = 42;");
+
+console.log(output.source());
+```
+
+The filename determines how the source is parsed. `source()` returns the generated JavaScript, and `sourceMap()` returns a JSON source map or `null`.
+
+## Supported files
+
+The register hook transforms the following extensions:
+
+```
+.js .jsx .ts .tsx .mjs .mts .cjs .cts .es6 .es
+```
+
+Module format is inferred from the file extension, the nearest `package.json`, and `tsconfig.json`. Files in `node_modules` are not transformed by default. Set `OXC_TRANSFORM_ALL=1` to transform them as well.
+
+## TypeScript configuration
+
+Oxc Node reads `tsconfig.json` from the current working directory. Set `OXC_TSCONFIG_PATH` or `TS_NODE_PROJECT` to use a different file:
+
+```sh
+OXC_TSCONFIG_PATH=./config/tsconfig.dev.json oxnode ./src/index.ts
+```
+
+The transformer uses relevant compiler options for module format, JSX, decorators, class fields, and rewriting relative import extensions. TypeScript types are stripped during transformation; Oxc Node does not type-check your program.
+
+## Links
+
+- [Oxc Node repository](https://github.com/oxc-project/oxc-node)
+- [`@oxc-node/cli`](https://npmx.dev/package/@oxc-node/cli)
+- [`@oxc-node/core`](https://npmx.dev/package/@oxc-node/core)

--- a/src/docs/guide/what-is-oxc.md
+++ b/src/docs/guide/what-is-oxc.md
@@ -47,7 +47,7 @@ Oxc includes end-user tools and reusable compiler building blocks:
 - [Transformer](/docs/guide/usage/transformer) provides fastest TS, JSX, and modern JavaScript transforms.
 - [Minifier](/docs/guide/usage/minifier) is the fastest minifier for production output.
 - [Resolver](/docs/guide/usage/resolver) is the fastest module resolver for JS and TS projects.
-- [TypeScript Runner (Experimental)](/docs/guide/usage/oxc-node) runs TypeScript and JSX directly in Node.js.
+- [TypeScript Runner](/docs/guide/usage/oxc-node) runs TypeScript and JSX directly in Node.js.
 
 You can use each tool on its own, or use them together as one toolchain.
 

--- a/src/docs/guide/what-is-oxc.md
+++ b/src/docs/guide/what-is-oxc.md
@@ -47,7 +47,7 @@ Oxc includes end-user tools and reusable compiler building blocks:
 - [Transformer](/docs/guide/usage/transformer) provides fastest TS, JSX, and modern JavaScript transforms.
 - [Minifier](/docs/guide/usage/minifier) is the fastest minifier for production output.
 - [Resolver](/docs/guide/usage/resolver) is the fastest module resolver for JS and TS projects.
-- [TypeScript Runner](/docs/guide/usage/oxc-node) runs TypeScript and JSX directly in Node.js.
+- [TypeScript Runner (Experimental)](/docs/guide/usage/oxc-node) runs TypeScript and JSX directly in Node.js.
 
 You can use each tool on its own, or use them together as one toolchain.
 

--- a/src/docs/guide/what-is-oxc.md
+++ b/src/docs/guide/what-is-oxc.md
@@ -47,6 +47,7 @@ Oxc includes end-user tools and reusable compiler building blocks:
 - [Transformer](/docs/guide/usage/transformer) provides fastest TS, JSX, and modern JavaScript transforms.
 - [Minifier](/docs/guide/usage/minifier) is the fastest minifier for production output.
 - [Resolver](/docs/guide/usage/resolver) is the fastest module resolver for JS and TS projects.
+- [Oxc Node](/docs/guide/usage/oxc-node) runs TypeScript and JSX directly in Node.js.
 
 You can use each tool on its own, or use them together as one toolchain.
 

--- a/src/docs/guide/what-is-oxc.md
+++ b/src/docs/guide/what-is-oxc.md
@@ -47,7 +47,7 @@ Oxc includes end-user tools and reusable compiler building blocks:
 - [Transformer](/docs/guide/usage/transformer) provides fastest TS, JSX, and modern JavaScript transforms.
 - [Minifier](/docs/guide/usage/minifier) is the fastest minifier for production output.
 - [Resolver](/docs/guide/usage/resolver) is the fastest module resolver for JS and TS projects.
-- [Oxc Node](/docs/guide/usage/oxc-node) runs TypeScript and JSX directly in Node.js.
+- [TypeScript Runner](/docs/guide/usage/oxc-node) runs TypeScript and JSX directly in Node.js.
 
 You can use each tool on its own, or use them together as one toolchain.
 


### PR DESCRIPTION
Document the `oxc-node` TypeScript runner and add it to the website navigation.

Validation: `vp check`, `vp run build`, and `typos`.