### PR TITLE
feat: add `oxc-codegen` docs

### DIFF
--- a/.vitepress/config/en.ts
+++ b/.vitepress/config/en.ts
@@ -19,6 +19,7 @@ export const enConfig = defineLocaleConfig("root", {
           { text: "Linter (Oxlint)", link: "/docs/guide/usage/linter" },
           { text: "Formatter (Oxfmt)", link: "/docs/guide/usage/formatter" },
           { text: "Parser", link: "/docs/guide/usage/parser" },
+          { text: "Code Generator", link: "/docs/guide/usage/codegen" },
           { text: "Transformer", link: "/docs/guide/usage/transformer" },
           { text: "Minifier", link: "/docs/guide/usage/minifier" },
           { text: "Resolver", link: "/docs/guide/usage/resolver" },
@@ -206,6 +207,12 @@ export const enConfig = defineLocaleConfig("root", {
           collapsed: true,
           link: "/docs/guide/usage/parser",
           items: [{ text: "Overview", link: "/docs/guide/usage/parser" }],
+        },
+        {
+          text: "Code Generator",
+          collapsed: true,
+          link: "/docs/guide/usage/codegen",
+          items: [{ text: "Overview", link: "/docs/guide/usage/codegen" }],
         },
         {
           text: "Transformer",

--- a/.vitepress/config/shared.ts
+++ b/.vitepress/config/shared.ts
@@ -173,6 +173,7 @@ export const sharedConfig = {
             { text: "Linter", link: "/docs/guide/usage/linter" },
             { text: "Formatter", link: "/docs/guide/usage/formatter" },
             { text: "Parser", link: "/docs/guide/usage/parser" },
+            { text: "Code Generator", link: "/docs/guide/usage/codegen" },
             { text: "Transformer", link: "/docs/guide/usage/transformer" },
             { text: "Minifier", link: "/docs/guide/usage/minifier" },
             { text: "Resolver", link: "/docs/guide/usage/resolver" },

--- a/src/docs/guide/usage/codegen.md
+++ b/src/docs/guide/usage/codegen.md
@@ -1,0 +1,67 @@
+---
+title: Code Generator
+description: Print JavaScript, JSX, TypeScript, and TSX from ESTree-compatible ASTs with oxc-codegen.
+outline: deep
+---
+
+# Code Generator
+
+`oxc-codegen` is a fast JavaScript code generator from an [ESTree](https://github.com/estree/estree)-compatible AST.
+
+It is a faithful port of Oxc's Rust [`oxc_codegen`](https://github.com/oxc-project/oxc/tree/main/crates/oxc_codegen) crate in pretty-printing mode. With the default options, both printers produce byte-identical output: tab indentation, double quotes, and comments omitted.
+
+## Installation
+
+Install [`oxc-codegen`][url-oxc-codegen-npm] alongside the ESTree-compatible parser that produces your AST. To use it with [`oxc-parser`](./parser):
+
+```sh
+pnpm add oxc-codegen oxc-parser
+```
+
+## Usage
+
+```js
+import { parseSync } from "oxc-parser";
+import { printSync } from "oxc-codegen";
+
+const { program } = parseSync("foo.js", "let x = 1");
+console.log(printSync(program));
+```
+
+The printer supports JavaScript, JSX, TypeScript, and TSX ASTs.
+
+## API
+
+### `printSync(node, options?)`
+
+Returns the printed source code as a string. `node` must be a complete AST (`Program`) or a statement node.
+
+### Options
+
+| Option                | Type                 | Default | Description                                       |
+| :-------------------- | :------------------- | :------ | :------------------------------------------------ |
+| `indent`              | `string`             | `"\t"`  | Indentation; accepts spaces and tabs only         |
+| `startingIndentLevel` | `number`             | `0`     | Indentation level at which to start               |
+| `jsx`                 | `boolean`            | `false` | TSX mode; lone type parameters print as `<T,>`    |
+| `ts`                  | `boolean`            | `false` | Whether the AST may contain TypeScript syntax     |
+| `sourceMap`           | `SourceMapGenerator` | —       | Emits source mappings into the supplied generator |
+
+For a TypeScript or TSX AST, pass the matching options:
+
+```js
+const code = printSync(program, {
+  ts: true,
+  jsx: true,
+});
+```
+
+## Current limitations
+
+- Comments are not printed.
+- Only pretty-printing is supported; there is no compact or minified output mode.
+
+For compact production output, use the [Minifier](./minifier).
+
+<!-- Links -->
+
+[url-oxc-codegen-npm]: https://npmx.dev/package/oxc-codegen

--- a/src/docs/guide/usage/codegen.md
+++ b/src/docs/guide/usage/codegen.md
@@ -1,22 +1,24 @@
 ---
 title: Code Generator
-description: Print JavaScript, JSX, TypeScript, and TSX from ESTree-compatible ASTs with oxc-codegen.
+description: Print JavaScript, JSX, TypeScript, and TSX from ESTree and TS-ESTree ASTs with oxc-codegen.
 outline: deep
 ---
 
 # Code Generator
 
-`oxc-codegen` is a fast JavaScript code generator from an [ESTree](https://github.com/estree/estree)-compatible AST.
+`oxc-codegen` is a fast, synchronous code generator for [ESTree](https://github.com/estree/estree) and [TS-ESTree](https://typescript-eslint.io/packages/typescript-estree/) ASTs.
 
 It is a faithful port of Oxc's Rust [`oxc_codegen`](https://github.com/oxc-project/oxc/tree/main/crates/oxc_codegen) crate in pretty-printing mode. With the default options, both printers produce byte-identical output: tab indentation, double quotes, and comments omitted.
 
 ## Installation
 
-Install [`oxc-codegen`][url-oxc-codegen-npm] alongside the ESTree-compatible parser that produces your AST. To use it with [`oxc-parser`](./parser):
+Install [`oxc-codegen`][url-oxc-codegen-npm] alongside the parser that produces your AST. To use it with [`oxc-parser`](./parser):
 
 ```sh
 pnpm add oxc-codegen oxc-parser
 ```
+
+`oxc-codegen` is ESM-only and requires Node.js `^20.19.0` or `>=22.12.0`.
 
 ## Usage
 
@@ -24,36 +26,59 @@ pnpm add oxc-codegen oxc-parser
 import { parseSync } from "oxc-parser";
 import { printSync } from "oxc-codegen";
 
-const { program } = parseSync("foo.js", "let x = 1");
-console.log(printSync(program));
+const { program } = parseSync("input.js", "const answer=6*7");
+const { code } = printSync(program);
+
+console.log(code);
+// const answer = 6 * 7;
 ```
 
-The printer supports JavaScript, JSX, TypeScript, and TSX ASTs.
+The printer supports JavaScript, JSX, TypeScript, and TSX ASTs. You can also print a manually constructed AST.
 
 ## API
 
 ### `printSync(node, options?)`
 
-Returns the printed source code as a string. `node` must be a complete AST (`Program`) or a statement node.
+Prints a complete `Program` or a single statement, returning an object with the generated `code` and a `map`.
+
+`map` is `null` unless source maps are enabled. When enabled, it is a standard Source Map v3 object.
 
 ### Options
 
-| Option                | Type                 | Default | Description                                       |
-| :-------------------- | :------------------- | :------ | :------------------------------------------------ |
-| `indent`              | `string`             | `"\t"`  | Indentation; accepts spaces and tabs only         |
-| `startingIndentLevel` | `number`             | `0`     | Indentation level at which to start               |
-| `jsx`                 | `boolean`            | `false` | TSX mode; lone type parameters print as `<T,>`    |
-| `ts`                  | `boolean`            | `false` | Whether the AST may contain TypeScript syntax     |
-| `sourceMap`           | `SourceMapGenerator` | —       | Emits source mappings into the supplied generator |
+| Option                | Type      | Default | Description                                                 |
+| :-------------------- | :-------- | :------ | :---------------------------------------------------------- |
+| `indent`              | `string`  | `"\t"`  | Non-empty string of spaces and/or tabs for one indent level |
+| `startingIndentLevel` | `number`  | `0`     | Starting indent level, from `0` to `1000`                   |
+| `jsx`                 | `boolean` | `false` | Enable TSX-safe printing for ambiguous TypeScript syntax    |
+| `ts`                  | `boolean` | `false` | Select the printer that supports TypeScript nodes           |
+| `sourcemap`           | `boolean` | `false` | Return a Source Map v3 object in `map`                      |
+| `sourceFilename`      | `string`  | `""`    | Original source filename recorded in the source map         |
+| `sourceText`          | `string`  | —       | Original source text, required when `sourcemap` is `true`   |
 
 For a TypeScript or TSX AST, pass the matching options:
 
 ```js
-const code = printSync(program, {
+const { code } = printSync(program, {
   ts: true,
   jsx: true,
 });
 ```
+
+### Source maps
+
+Enable source maps with `sourcemap: true` and provide the original source text. The AST must retain valid Oxc `start` and `end` offsets for mappings to be generated.
+
+```js
+const sourceText = "const answer=6*7";
+const { program } = parseSync("input.js", sourceText);
+const { code, map } = printSync(program, {
+  sourcemap: true,
+  sourceFilename: "input.js",
+  sourceText,
+});
+```
+
+Manually constructed ASTs without offsets can still be printed, but their source map has an empty `mappings` string.
 
 ## Current limitations
 

--- a/src/docs/guide/usage/parser.md
+++ b/src/docs/guide/usage/parser.md
@@ -32,23 +32,22 @@ Rust usage example can be found [here](https://github.com/oxc-project/oxc/blob/m
 
 ## Print
 
-After parsing and transforming, you can print code.
+After parsing or transforming, use [`oxc-codegen`](./codegen) to print the ESTree AST as source code.
 
-Here's a direct example using [esrap](https://npmx.dev/package/esrap) _(`parse` in reverse!)_:
+For example:
 
 ```js
-import { print } from "esrap";
-import ts from "esrap/languages/ts";
 import { parseSync } from "oxc-parser";
+import { printSync } from "oxc-codegen";
 
-const { program } = parseSync("test.js", 'alert("hello oxc & esrap");');
-const { code } = print(program, ts());
+const { program } = parseSync("test.js", 'alert("hello oxc");');
+const code = printSync(program);
 
-console.log(code); // alert("hello oxc & esrap");
+console.log(code); // alert("hello oxc");
 ```
 
 :::info
-Today, comments are not printed. _It will be supported thanks to [oxc-parser #13285](https://github.com/oxc-project/oxc/pull/13285)._
+`oxc-codegen` currently does not print comments. See the [Code Generator guide](./codegen#current-limitations) for the other current limitations.
 :::
 
 <!-- Links -->

--- a/src/docs/guide/usage/parser.md
+++ b/src/docs/guide/usage/parser.md
@@ -41,7 +41,7 @@ import { parseSync } from "oxc-parser";
 import { printSync } from "oxc-codegen";
 
 const { program } = parseSync("test.js", 'alert("hello oxc");');
-const code = printSync(program);
+const { code } = printSync(program);
 
 console.log(code); // alert("hello oxc");
 ```


### PR DESCRIPTION
Adds docs following https://github.com/oxc-project/oxc/commit/a4478e960a1d0bc7e2481e606d937c6d5f3bf540, https://npmx.dev/package/oxc-codegen