### PR TITLE
fix(docs): update React Compiler rule links

### DIFF
--- a/src/docs/guide/usage/linter/plugins.md
+++ b/src/docs/guide/usage/linter/plugins.md
@@ -127,7 +127,7 @@ This table lists the built-in plugins and where they come from.
 
 For the current status of rule coverage, see the linter [product plan issue](https://github.com/oxc-project/oxc/issues/481). For framework and file type support, see the [compatibility matrix](/compatibility).
 
-\* The React Compiler rules are implemented natively as the [`react/react-compiler`](./rules/react/react-compiler) rule, which runs the React Compiler's analysis in lint-only mode. It is experimental and off by default, so it must be enabled explicitly.
+\* The [React Compiler rules](/blog/2026-08-18-react-compiler-support#oxlint) are implemented natively as category-specific `react/*` rules, which run the React Compiler's analysis in lint-only mode. They are experimental and off by default, so the React plugin and the desired rule categories must be enabled explicitly.
 
 ## Adding new plugins
 

--- a/src/docs/guide/usage/transformer/react-compiler.md
+++ b/src/docs/guide/usage/transformer/react-compiler.md
@@ -41,4 +41,4 @@ This is why Oxc runs the React Compiler before its own JSX transform.
 
 Code that breaks the [Rules of React](https://react.dev/reference/rules) is also skipped rather than optimized — for example interior mutability, or libraries built on observable mutation such as MobX's `observer()`.
 
-To find that code, Oxlint has an experimental [`react/react-compiler`](../linter/rules/react/react-compiler) rule that runs the same analysis in lint-only mode and reports the violations.
+To find that code, Oxlint has experimental [React Compiler-powered rules](/blog/2026-08-18-react-compiler-support#oxlint) that run the same analysis in lint-only mode and report specific categories of violations.


### PR DESCRIPTION
Updates stale React Compiler links after the single rule page was replaced by category-specific rules. This restores the site build.