### PR TITLE
docs(oxfmt): document operator position support

### DIFF
--- a/src/docs/guide/usage/formatter/unsupported-features.md
+++ b/src/docs/guide/usage/formatter/unsupported-features.md
@@ -14,7 +14,7 @@ Not currently supported:
 
 - `prettier` field in `package.json`
 - Nested `.editorconfig` in sub directories
-- `experimentalTernaries` and `experimentalOperatorPosition` options
+- `experimentalTernaries` option
 
 Note: Default `printWidth` is `100` (Prettier uses `80`).
 


### PR DESCRIPTION
Updates Oxfmt's unsupported features list now that `experimentalOperatorPosition` is supported.