### PR TITLE
docs: align website with recent changes

### DIFF
--- a/src/docs/guide/usage/linter/ignore-files.md
+++ b/src/docs/guide/usage/linter/ignore-files.md
@@ -16,9 +16,11 @@ Oxlint automatically ignores:
 
 - `.git` directories
 - Minified files containing `.min.`, `-min.`, or `_min.` in the file name
-- Files matched by `.gitignore` (global gitignore files are not respected)
+- Files discovered through directory traversal that are matched by `.gitignore` (global gitignore files are not respected)
 
 Hidden files are not automatically ignored.
+
+`.gitignore` scopes file discovery. An explicitly named file is still linted even if it is matched by `.gitignore`, while an explicitly named ignored directory is skipped because its contents would need to be discovered.
 
 ## `ignorePatterns`
 
@@ -100,8 +102,10 @@ This keeps traversal possible while still ignoring almost everything.
 
 ## Disable ignoring
 
-To disable all ignore behavior, including ignore files and CLI ignore options, use `--no-ignore`:
+To disable `.eslintignore`, `--ignore-path`, and `--ignore-pattern`, use `--no-ignore`:
 
 ```bash
 oxlint --no-ignore
 ```
+
+This does not disable `ignorePatterns` from the Oxlint config or `.gitignore` filtering during directory discovery.

--- a/src/docs/guide/usage/linter/quickstart.md
+++ b/src/docs/guide/usage/linter/quickstart.md
@@ -194,7 +194,7 @@ Add ignore patterns from the command line:
 oxlint --ignore-pattern "dist/**" --ignore-pattern "*.min.js"
 ```
 
-Disable ignore handling:
+Disable `.eslintignore` and CLI ignore options:
 
 ```sh
 oxlint --no-ignore

--- a/src/docs/guide/usage/minifier/mangling.md
+++ b/src/docs/guide/usage/minifier/mangling.md
@@ -22,10 +22,8 @@ import { minify } from "oxc-minify";
 
 const result = await minify("lib.js", code, {
   module: false, // non-module code
-  compress: {
-    mangle: {
-      toplevel: true,
-    },
+  mangle: {
+    toplevel: true,
   },
 });
 ```
@@ -47,10 +45,8 @@ var foo = function () {};
 import { minify } from "oxc-minify";
 
 const result = await minify("lib.js", code, {
-  compress: {
-    mangle: {
-      keepNames: true, // shorthand of { function: true, class: true }
-    },
+  mangle: {
+    keepNames: true, // shorthand of { function: true, class: true }
   },
 });
 ```
@@ -78,10 +74,8 @@ var slot_0 = 1;
 import { minify } from "oxc-minify";
 
 const result = await minify("lib.js", code, {
-  compress: {
-    mangle: {
-      debug: true,
-    },
+  mangle: {
+    debug: true,
   },
 });
 ```

--- a/src/docs/guide/usage/transformer.md
+++ b/src/docs/guide/usage/transformer.md
@@ -4,7 +4,7 @@ A high-performance transformer that rewrites unsupported syntax into forms suppo
 
 ## Features
 
-The features below run in a fixed order, regardless of the order of the options:
+Oxc's transform pipelines run their supported features in a fixed order, regardless of the order of the options:
 
 1. **[React Compiler](./transformer/react-compiler)** — runs first, on the original source.
 2. **[TypeScript](./transformer/typescript)** — type stripping.
@@ -15,6 +15,8 @@ The features below run in a fixed order, regardless of the order of the options:
 7. **[Lowering](./transformer/lowering)** — ES2026 down to ES2015.
 8. **[Inject](./transformer/global-variable-replacement#inject)** — global variable injection.
 9. **[Define](./transformer/global-variable-replacement#define)** — global variable replacement.
+
+`oxc-transform` exposes steps 2–9. The dedicated `oxc-transform-react` package runs the React Compiler first, followed by TypeScript syntax removal, React Refresh, and JSX transformation.
 
 Oxc also supports [TypeScript Isolated Declarations emit](./transformer/isolated-declarations) without using the TypeScript compiler.
 

--- a/src/docs/guide/usage/transformer/global-variable-replacement.md
+++ b/src/docs/guide/usage/transformer/global-variable-replacement.md
@@ -29,7 +29,20 @@ const result = await transform("lib.js", sourceCode, {
 });
 ```
 
-Each `define` entry maps an expression to a string of code containing an expression. The keys of it must be an identifier (e.g. `__DEV__`), or a dotted sequence of identifiers (e.g. `process.env.NODE_ENV`, `import.meta.env.MODE`). The values of it must be a valid expression.
+Each `define` entry maps an expression to a string of code containing an expression. A key can be
+an identifier (for example, `__DEV__`), a dotted sequence of identifiers (for example,
+`process.env.NODE_ENV` or `import.meta.env.MODE`), or a `typeof` expression over either form (for
+example, `typeof window` or `typeof globalThis.process`). The value must be a valid expression.
+
+```js
+import { transform } from "oxc-transform";
+
+const result = await transform("lib.js", sourceCode, {
+  define: {
+    "typeof window": '"undefined"',
+  },
+});
+```
 
 ::: tip Always quote the values
 

--- a/src/docs/guide/usage/transformer/plugins.md
+++ b/src/docs/guide/usage/transformer/plugins.md
@@ -58,14 +58,18 @@ const Button = styled.div`
 
 **Output (with default options):**
 
+<!-- prettier-ignore-start -->
+
 ```jsx
 import styled from "styled-components";
 
 const Button = styled.div.withConfig({
   displayName: "Button",
   componentId: "sc-1234567-0",
-})(["color:blue;padding:10px;"]);
+})`color:blue;padding:10px;`;
 ```
+
+<!-- prettier-ignore-end -->
 
 ### Configuration Options
 
@@ -79,10 +83,14 @@ const Button = styled.div.withConfig({
 
 #### Template Literal Options
 
-| Option                      | Type      | Default | Description                                                                    |
-| --------------------------- | --------- | ------- | ------------------------------------------------------------------------------ |
-| `transpileTemplateLiterals` | `boolean` | `true`  | Converts template literals to a smaller representation for reduced bundle size |
-| `minify`                    | `boolean` | `true`  | Minifies CSS content by removing whitespace and comments                       |
+| Option                      | Type      | Default | Description                                                  |
+| --------------------------- | --------- | ------- | ------------------------------------------------------------ |
+| `transpileTemplateLiterals` | `boolean` | `false` | Converts tagged template literals to an array representation |
+| `minify`                    | `boolean` | `true`  | Minifies CSS content by removing whitespace and comments     |
+
+`transpileTemplateLiterals` is disabled by default because Oxc does not lower template literals
+to ES5. Without that subsequent lowering, the array representation increases output size. Enable
+it only when a downstream transform will lower template literals.
 
 #### Advanced Options
 

--- a/src/docs/guide/usage/transformer/react-compiler.md
+++ b/src/docs/guide/usage/transformer/react-compiler.md
@@ -6,20 +6,24 @@ Oxc has experimental support for the [React Compiler](https://react.dev/learn/re
 This feature is experimental and under active development. Options and behaviour may change.
 :::
 
-Under the hood, Oxc integrates the [Rust port of the React Compiler](https://github.com/facebook/react/pull/36173) rather than the Babel-based `babel-plugin-react-compiler`. Because that port is an merged React PR, but unpublished, Oxc vendors it as releasable crates at [oxc-project/forked-react-compiler](https://github.com/oxc-project/forked-react-compiler).
+Under the hood, Oxc integrates the [Rust port of the React Compiler](https://github.com/facebook/react/pull/36173) rather than the Babel-based `babel-plugin-react-compiler`. Oxc [vendors and maintains the compiler in-tree](https://github.com/oxc-project/oxc/tree/main/crates/oxc_react_compiler), allowing it to operate directly on Oxc's AST.
 
 ## General Usage
 
+Install the dedicated React transform package:
+
+```sh
+pnpm add -D oxc-transform-react
+```
+
 ```js
-import { transform } from "oxc-transform";
+import { transform } from "oxc-transform-react";
 
-// Enable with default options.
-const result = await transform("App.jsx", sourceCode, {
-  reactCompiler: true,
-});
+// React Compiler is enabled by default with a React 19 target.
+const result = await transform("App.jsx", sourceCode);
 
-// Or enable with options.
-const result = await transform("App.jsx", sourceCode, {
+// Or configure it explicitly.
+const configuredResult = await transform("App.jsx", sourceCode, {
   reactCompiler: {
     // React runtime version target. `'17'` and `'18'` require the
     // `react-compiler-runtime` package; `'19'` ships the runtime in `react`.
@@ -28,7 +32,9 @@ const result = await transform("App.jsx", sourceCode, {
 });
 ```
 
-Pass `false` or omit the option to disable the React Compiler.
+Pass `reactCompiler: false` to disable the React Compiler. Omitting the option enables it with the default configuration.
+
+Files whose filename contains `node_modules` are skipped by default. Providing a `reactCompiler.sources` allowlist replaces that default filter, so dependencies can be opted in explicitly.
 
 ## When the React Compiler won't work
 


### PR DESCRIPTION
Align the website with recent Oxc behavior and package changes, correcting stale examples and option defaults.