### PR TITLE
docs(oxfmt): Add note for unsupported sort-imports options

### DIFF
--- a/src/docs/guide/usage/formatter/sorting.md
+++ b/src/docs/guide/usage/formatter/sorting.md
@@ -146,6 +146,9 @@ export default defineConfig({
 
 :::
 
+Not every `perfectionist` option is available. In particular, options that rely on information outside the source file are not supported.
+e.g. `tsconfigPath`, which resolves TypeScript path aliases via `tsconfig.json`. To classify aliased imports as internal, list their prefixes in `internalPattern`, or match them with `customGroups`.
+
 ## Sort Tailwind CSS classes
 
 Sorts Tailwind utility classes.


### PR DESCRIPTION
Follow up on https://github.com/oxc-project/oxc/issues/25795
