### PR TITLE
docs(minifier): document property-name mangling

### DIFF
--- a/src/docs/guide/usage/minifier.md
+++ b/src/docs/guide/usage/minifier.md
@@ -6,7 +6,7 @@ A high-performance minifier that shrinks your code by removing unused code and t
 
 - [Eliminate dead code.](./minifier/dead-code-elimination)
 - [Transforms syntaxes to make the output shorter and repetitive.](./minifier/syntax-normalization)
-- [Mangle variable names.](./minifier/mangling)
+- [Mangle variable names and selected property names.](./minifier/mangling)
 - [Remove whitespace and comments.](./minifier/whitespace-stripping)
 
 ## Assumptions

--- a/src/docs/guide/usage/minifier/mangling.md
+++ b/src/docs/guide/usage/minifier/mangling.md
@@ -1,12 +1,14 @@
 # Mangling
 
-Oxc minifier supports mangling variable names and private class fields.
+Oxc minifier can shorten variable names and selected property names.
 
-This feature is enabled by default and can be disabled by setting the `mangle` option to `false`.
+## Variable Names
 
-## Top Level Variables
+Variable-name mangling is enabled by default. Set `mangle` to `false` to disable it, or pass an object to configure it. Use `mangle.reserved` to keep exact binding names unchanged and prevent Oxc from generating them.
 
-Top level variables are not mangled by default for non module code. You can enable mangling for top level variables by setting the `mangle.toplevel` option to `true`.
+### Top-Level Variables
+
+Top-level names are mangled by default in modules and CommonJS files, but not in scripts. Set `mangle.toplevel` to override this.
 
 ```js
 // input
@@ -21,16 +23,15 @@ var e = 1;
 import { minify } from "oxc-minify";
 
 const result = await minify("lib.js", code, {
-  module: false, // non-module code
   mangle: {
     toplevel: true,
   },
 });
 ```
 
-## Keep `name` Property Values
+### Keep `name` Property Values
 
-Mangling variable names can change the `name` property values of functions / classes. You can keep the original `name` property values by enabling the `mangle.keepNames` option.
+Mangling variable names can change the `name` property values of functions and classes. Set `mangle.keepNames` to preserve them.
 
 ```js
 // input
@@ -57,7 +58,7 @@ When enabling this option, you may also want to enable [the `compress.keepNames`
 
 :::
 
-## Debugging The Mangler
+### Debugging the Mangler
 
 To debug the mangler, you can enable the `mangle.debug` option. When this option is enabled, the mangler will use `slot_0`, `slot_1`, ... as variable names.
 
@@ -76,6 +77,39 @@ import { minify } from "oxc-minify";
 const result = await minify("lib.js", code, {
   mangle: {
     debug: true,
+    toplevel: true,
   },
 });
 ```
+
+## Property Names
+
+Property-name mangling is off by default. Use `mangleProps.include` to select the property names to mangle.
+
+```js
+import { minify } from "oxc-minify";
+
+const result = await minify("lib.js", code, {
+  mangleProps: {
+    include: /^_/,
+    exclude: /^__public/,
+    reserved: ["_externalApi"],
+  },
+});
+```
+
+`exclude` removes matching property names from the set selected by `include`. `reserved` keeps the listed exact names unchanged and also prevents Oxc from generating them as replacement names. Neither option adds entries to `mangleCache` by itself.
+
+Quoted occurrences such as `obj["_field"]` are kept by default. This is handled per occurrence, so an unquoted use of the same name may still be mangled. Set `quoted` to `true` to mangle quoted occurrences too, or `debug` to `true` for readable generated property names.
+
+The filters are JavaScript `RegExp` objects, but Oxc matches them with Rust's [regex engine](https://docs.rs/regex/latest/regex/#syntax). It supports the `i`, `m`, `s`, and `u` flags and reports unsupported syntax or flags in `result.errors`.
+
+To keep names stable when the source changes, reuse `result.mangleCache` as `mangleProps.cache`. A `false` cache entry keeps that property unchanged. Always start from unminified source; do not apply the same cache to already-mangled output.
+
+::: warning
+
+Only mangle properties owned by the code being minified. Oxc cannot safely update names built at runtime or used by unminified code. Exclude or reserve matching names used by public APIs, through module namespace objects, or on globals, DOM APIs, and other host APIs. A cache alone does not make separately minified files safe.
+
+For more details, see the [property-name assumptions](https://github.com/oxc-project/oxc/blob/main/crates/oxc_minifier/docs/ASSUMPTIONS.md#property-names-selected-for-mangling-are-not-accessed-dynamically).
+
+:::


### PR DESCRIPTION
The minifier guide only explained variable-name mangling, even though `oxc-minify` can also mangle selected property names. Users had to read the generated API types to learn how to enable it and which names were safe to change.

The guide now groups the existing `mangle` options and documents `mangleProps`, including cache reuse and names that should be reserved or excluded. Less common property edge cases remain in the full assumptions document.